### PR TITLE
Refactoring primitive types

### DIFF
--- a/lib/toml.citrus
+++ b/lib/toml.citrus
@@ -1,6 +1,6 @@
 grammar Primitive
   rule primitive
-    string | bool | datetime | float | integer
+    string | bool | datetime | number
   end
 
   rule string
@@ -16,6 +16,10 @@ grammar Primitive
     (y:/\d\d\d\d/ "-" m:/\d\d/ "-" d:/\d\d/ "T" h:/\d\d/ ":" mi:/\d\d/ ":" s:/\d\d/ "Z") {
       Time.utc(*[y,m,d,h,mi,s].map(&:value))
     }
+  end
+
+  rule number
+    float | integer
   end
 
   rule float


### PR DESCRIPTION
The idea for this patch came from this line in the `keyvalue` rule.

``` ruby
def val
  datetime ? datetime.value : eval(string || bool || float || array)
end
```

I think each data type should know how to return it's own `value`, making the `if` superfluous.
