### PR TITLE
Add test for dangerous arrays

### DIFF
--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -84,8 +84,8 @@ class GrammarTest < Test::Unit::TestCase
     match = Document.parse('[ 2.4, 4.72]', root: :array)
     assert_equal([2.4,4.72], match.value)
 
-    match = Document.parse('[ "hey", "TOML"]', root: :array)
-    assert_equal(["hey","TOML"], match.value)
+    match = Document.parse('[ "hey", "TOML", "#{2+2}"]', root: :array)
+    assert_equal(['hey','TOML', '#{2+2}'], match.value)
 
     match = Document.parse('[ ["hey", "TOML"], [2,4] ]', root: :array)
     assert_equal([["hey","TOML"], [2,4]], match.value)


### PR DESCRIPTION
:warning: Given we use `eval(self)` to parse an array, some exploits can be
introduced into an array definition.

I created this pull request to isolate the test until is solved.
