### PR TITLE
init.rb file missing

### DIFF
--- a/toml-rb.gemspec
+++ b/toml-rb.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
     "lib/**/*.rb",
     "lib/**/*.citrus",
     "*.gemspec",
-    "test/*.*"
+    "test/*.*",
+    "init.rb"
   ]
 
   s.add_dependency "citrus"


### PR DESCRIPTION
Hey,

the init.rb file was missing from the current version, so I added it to the list of files in the gemspec file.
