### PR TITLE
Fixed parsing of empty array and inline table array

### DIFF
--- a/lib/toml/grammars/array.citrus
+++ b/lib/toml/grammars/array.citrus
@@ -2,7 +2,7 @@ grammar TomlArray
   include Primitive
 
   rule array
-    ("[" array_comments (elements)* ","? array_comments "]" indent?) { eval(to_str) }
+    ("[" array_comments (elements)? space ","? array_comments "]" indent?) { eval(to_str) }
   end
 
   rule array_comments
@@ -14,26 +14,26 @@ grammar TomlArray
   end
 
   rule float_array
-    (float ("," array_comments float)*)
+    (float (space "," array_comments float)*)
   end
 
   rule string_array
-    (string ("," array_comments string)*)
+    (string (space "," array_comments string)*)
   end
 
   rule array_array
-    (array ("," array_comments array)*)
+    (array (space "," array_comments array)*)
   end
 
   rule integer_array
-    (integer ("," array_comments integer)*)
+    (integer (space "," array_comments integer)*)
   end
 
   rule datetime_array
-    (datetime ("," array_comments datetime)*)
+    (datetime (space "," array_comments datetime)*)
   end
 
   rule bool_array
-    (bool ("," array_comments bool)*)
+    (bool (space "," array_comments bool)*)
   end
 end

--- a/lib/toml/grammars/document.citrus
+++ b/lib/toml/grammars/document.citrus
@@ -23,15 +23,15 @@ grammar Document
   end
 
   rule inline_table_array
-    ("[" indent? (hash_array)+ ","? indent? comment? indent? "]" indent?) <InlineTableArray>
+    ("[" array_comments inline_table_array_elements space ","? array_comments "]" indent?) <InlineTableArray>
   end
 
-  rule hash_array
-    comment | (inline_table ("," indent? (inline_table | comment))*)
+  rule inline_table_array_elements
+    (inline_table (space "," array_comments inline_table)*)
   end
 
   rule toml_values
-    primitive | inline_table_array | inline_table | array
+    primitive | inline_table | array | inline_table_array
   end
 
 

--- a/lib/toml/grammars/document.citrus
+++ b/lib/toml/grammars/document.citrus
@@ -23,7 +23,7 @@ grammar Document
   end
 
   rule inline_table_array
-    ("[" indent? (hash_array)* ","? indent? comment? indent? "]" indent?) <InlineTableArray>
+    ("[" indent? (hash_array)+ ","? indent? comment? indent? "]" indent?) <InlineTableArray>
   end
 
   rule hash_array

--- a/lib/toml/inline_table.rb
+++ b/lib/toml/inline_table.rb
@@ -63,8 +63,8 @@ end
 
 module InlineTableArray
   def value
-    tables = captures[:hash_array].map { |x| x.captures[:inline_table] }
+    tables = captures[:inline_table_array_elements].map { |x| x.captures[:inline_table] }
 
-    TOML::InlineTableArray.new tables.flatten.map(&:value)
+    TOML::InlineTableArray.new(tables.flatten.map(&:value)).value
   end
 end

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -169,11 +169,11 @@ class GrammarTest < Test::Unit::TestCase
     match = Document.parse(multiline_array, root: :array)
     assert_equal([4], match.value)
 
-    multiline_array = "[\n  1,\n  # 2,\n  3,\n]"
+    multiline_array = "[\n  1,\n  # 2,\n  3 ,\n]"
     match = Document.parse(multiline_array, root: :array)
     assert_equal([1, 3], match.value)
 
-    multiline_array = "[\n  1, # useless comment\n  # 2,\n  3 #other comment\n]"
+    multiline_array = "[\n  1 , # useless comment\n  # 2,\n  3 #other comment\n]"
     match = Document.parse(multiline_array, root: :array)
     assert_equal([1, 3], match.value)
   end

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -151,6 +151,12 @@ class GrammarTest < Test::Unit::TestCase
     assert_equal([{ 'one' => 1 }, { 'two' => 2, 'three' => 3 }], match.value)
   end
 
+  def test_empty_array
+    # test that [] is parsed as array and not as inline table array
+    match = Document.parse("a = []", root: :keyvalue).value
+    assert_equal [], match.value
+  end
+
   def test_multiline_array
     multiline_array = "[ \"hey\",\n   \"ho\",\n\t \"lets\", \"go\",\n ]"
     match = Document.parse(multiline_array, root: :array)

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -146,8 +146,7 @@ class GrammarTest < Test::Unit::TestCase
     assert_equal([%w(hey TOML), [2, 4]], match.value)
 
     match = Document.parse('[ { one = 1 }, { two = 2, three = 3} ]',
-                           root: :inline_table_array).value
-
+                           root: :inline_table_array)
     assert_equal([{ 'one' => 1 }, { 'two' => 2, 'three' => 3 }], match.value)
   end
 


### PR DESCRIPTION
Fixes #64 as well as fixes inline table array parsing (previously was returning array of TOML::InlineTableArray objects).