### PR TITLE
Fix NameError for Set

### DIFF
--- a/lib/toml/parser.rb
+++ b/lib/toml/parser.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module TOML
   class Parser
     attr_reader :hash


### PR DESCRIPTION
This pull request fixes the following issue (#73):

```
$ ruby -r toml -e 'TOML.parse("")'
/Users/ot/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/toml-rb-0.3.7/lib/toml/parser.rb:7:in `initialize': uninitialized constant TOML::Parser::Set (NameError)
	from /Users/ot/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/toml-rb-0.3.7/lib/toml.rb:30:in `new'
	from /Users/ot/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/toml-rb-0.3.7/lib/toml.rb:30:in `parse'
	from -e:1:in `<main>'
```
