### PR TITLE
Remove reference to dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,11 @@ Contributing
 ------------
 
 1. Fork it
-2. Bundle it `$ dep install` (install [dep](https://github.com/cyx/dep) if you don't have it)
-3. Create your feature branch `git checkout -b my-new-feature`
-4. Add tests and commit your changes `git commit -am 'Add some feature'`
-5. Run tests `$ rake`
-6. Push the branch `git push origin my-new-feature`
-7. Create new Pull Request
+2. Create your feature branch `git checkout -b my-new-feature`
+3. Add tests and commit your changes `git commit -am 'Add some feature'`
+4. Run tests `$ rake`
+5. Push the branch `git push origin my-new-feature`
+6. Create new Pull Request
 
 License
 -------


### PR DESCRIPTION
When first considering which TOML library to use, I was put off by reference to `dep` here.

This PR removes the reference to `dep` in the README. On closer inspection, your library is by far the most robust for TOML parsing, and I'm going to be using it - I wouldn't want anyone else to make the mistake I did!