### PR TITLE
Fix comment parsing

### DIFF
--- a/lib/toml-rb/grammars/array.citrus
+++ b/lib/toml-rb/grammars/array.citrus
@@ -6,7 +6,7 @@ grammar TomlRB::Arrays
   end
 
   rule array_comments
-    (indent? comment* indent?)
+    (indent? (comment indent?)*)
   end
 
   rule elements

--- a/test/examples/valid/comments-everywhere.toml
+++ b/test/examples/valid/comments-everywhere.toml
@@ -19,6 +19,8 @@ more = [ # Comment
   # Can you handle it?
   #
           # Evil.
+
+  # Such evil
 # Evil.
 # ] Did I fool you?
 ] # Hopefully not.

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -4,7 +4,7 @@ require_relative 'helper'
 class GrammarTest < Minitest::Test
   def test_comment
     match = TomlRB::Document.parse(' # A comment', root: :comment)
-    assert_equal(nil, match.value)
+    assert_nil(match.value)
   end
 
   def test_key


### PR DESCRIPTION
First up, thanks for `toml-rb`! I use it in Dependabot and it's rad.

I came across a valid TOML file that it couldn't parse ([this one](https://github.com/gotham-rs/gotham/blob/master/Cargo.toml)) and dug into how the grammars work. This PR fixes the issue, which was that linespaces between comment lines were causing issues. I've added a test, too.

To make it easier for others to get up-and-running hacking on the library I've also committed the setup steps I made (i.e., adding support for Bundler) and cleaned up some deprecation warnings.