### PR TITLE
Distinguish between "TomlRB" and "TOML" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ toml-rb
 [![Code Climate](https://codeclimate.com/github/emancu/toml-rb/badges/gpa.svg)](https://codeclimate.com/github/emancu/toml-rb)
 [![Dependency Status](https://gemnasium.com/emancu/toml-rb.svg)](https://gemnasium.com/emancu/toml-rb)
 
-A [TomlRB](https://github.com/toml-lang/toml) parser using [Citrus](http://mjackson.github.io/citrus) library.
+A [TOML](https://github.com/toml-lang/toml) parser using [Citrus](http://mjackson.github.io/citrus) library.
 
-TomlRB specs supported: `0.4.0`
+TOML specs supported: `0.4.0`
 
 Installation
 ------------


### PR DESCRIPTION
In commit 466fb67ce72b2c4c7a8c309a29f22db40049e52f, a find-and-replace
operation mistakenly replaced "TOML" with "TomlRB" in the README where
"TOML" was meant.