### PR TITLE
Add a license file and only only ship necessary libs in the gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 
 before_install: gem install dep
 install: dep install

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/toml-rb.gemspec
+++ b/toml-rb.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
     'LICENSE'
   ]
 
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = '>= 2.2'
   s.add_dependency 'citrus', '~> 3.0', '> 3.0'
 end

--- a/toml-rb.gemspec
+++ b/toml-rb.gemspec
@@ -6,16 +6,14 @@ Gem::Specification.new do |s|
   s.description = 'A Toml parser using Citrus parsing library. '
   s.authors     = ['Emiliano Mancuso', 'Lucas Tolchinsky']
   s.email       = ['emiliano.mancuso@gmail.com', 'lucas.tolchinsky@gmail.com']
-  s.homepage    = 'http://github.com/emancu/toml-rb'
+  s.homepage    = 'https://github.com/emancu/toml-rb'
   s.license     = 'MIT'
 
   s.files = Dir[
     'README.md',
-    'Rakefile',
     'lib/**/*.rb',
     'lib/**/*.citrus',
-    '*.gemspec',
-    'test/*.*',
+    'LICENSE'
   ]
 
   s.required_ruby_version = '>= 1.9'


### PR DESCRIPTION
This adds a license file for services (like github) that parse out
licenses from a license file. It also stips the gemspec down to only
ship the necessary files in the gem artifact. There's no need for the
test files in the gem artifact and they make ruby installs larger.

Signed-off-by: Tim Smith <tsmith@chef.io>