### PR TITLE
Please support dotted_keys

### DIFF
--- a/lib/toml-rb.rb
+++ b/lib/toml-rb.rb
@@ -3,10 +3,10 @@ require 'citrus'
 require_relative "toml-rb/errors"
 require_relative "toml-rb/array"
 require_relative "toml-rb/string"
+require_relative "toml-rb/table"
 require_relative "toml-rb/table_array"
 require_relative "toml-rb/inline_table"
 require_relative "toml-rb/keyvalue"
-require_relative "toml-rb/keygroup"
 require_relative "toml-rb/parser"
 require_relative "toml-rb/dumper"
 

--- a/lib/toml-rb/array.rb
+++ b/lib/toml-rb/array.rb
@@ -1,14 +1,8 @@
 module TomlRB
   module ArrayParser
     def value
-      elements = captures[:elements].first
-      return [] unless elements
-
-      if elements.captures.key? :string
-        elements.captures[:string].map(&:value)
-      else
-        eval(to_str)
-      end
+      elements = captures[:array_elements].first
+      return elements ? elements.value : []
     end
   end
 end

--- a/lib/toml-rb/grammars/array.citrus
+++ b/lib/toml-rb/grammars/array.citrus
@@ -1,39 +1,38 @@
 grammar TomlRB::Arrays
   include TomlRB::Primitive
 
-  rule array
-    ("[" array_comments (elements)? space ","? array_comments "]" indent?) <TomlRB::ArrayParser>
-  end
-
+  
   rule array_comments
     (indent? (comment indent?)*)
   end
 
-  rule elements
-    float_array | string_array | array_array | integer_array | datetime_array | bool_array
-  end
-
   rule float_array
-    ((exponent | float) (space "," array_comments (exponent | float))*)
+    (float (space "," array_comments float)*) {
+      captures[:float].map(&:value)
+    }
   end
 
   rule string_array
-    (string (space "," array_comments string)*)
-  end
-
-  rule array_array
-    (array (space "," array_comments array)*)
+    (string (space "," array_comments string)*) {
+      captures[:string].map(&:value)
+    }
   end
 
   rule integer_array
-    (integer (space "," array_comments integer)*)
+    (integer (space "," array_comments integer)*) {
+      captures[:integer].map(&:value)
+    }
   end
 
   rule datetime_array
-    (datetime (space "," array_comments datetime)*)
+    (datetime (space "," array_comments datetime)*) {
+      captures[:datetime].map(&:value)
+    }
   end
 
   rule bool_array
-    (bool (space "," array_comments bool)*)
+    (bool (space "," array_comments bool)*) {
+      captures[:bool].map(&:value)
+    }
   end
 end

--- a/lib/toml-rb/grammars/document.citrus
+++ b/lib/toml-rb/grammars/document.citrus
@@ -3,15 +3,15 @@ grammar TomlRB::Document
   include TomlRB::Arrays
 
   rule document
-    (comment | table_array | keygroup | keyvalue | line_break)*
+    (comment | table_array | table | keyvalue | line_break)*
   end
 
   rule table_array
     (space? '[[' stripped_key ("." stripped_key)* ']]' comment?) <TomlRB::TableArrayParser>
   end
 
-  rule keygroup
-    (space? '[' stripped_key ("." stripped_key)* ']' comment?) <TomlRB::KeygroupParser>
+  rule table
+    (space? '[' stripped_key ("." stripped_key)* ']' comment?) <TomlRB::TableParser>
   end
 
   rule keyvalue
@@ -19,15 +19,27 @@ grammar TomlRB::Document
   end
 
   rule inline_table
-    (space? '{' (keyvalue (',' keyvalue)*)? space? '}' ) <TomlRB::InlineTableParser>
+    (space? '{' (keyvalue? (',' keyvalue)*)? space? '}' ) <TomlRB::InlineTableParser>
   end
 
   rule inline_table_array
-    ("[" array_comments inline_table_array_elements space ","? array_comments "]" indent?) <TomlRB::InlineTableArrayParser>
+    (inline_table (space "," array_comments inline_table)*) {
+      captures[:inline_table].map(&:value).map(&:value)
+    }
   end
 
-  rule inline_table_array_elements
-    (inline_table (space "," array_comments inline_table)*)
+  rule array
+    ("[" array_comments (array_elements)? space ","? array_comments "]" indent?) <TomlRB::ArrayParser>
+  end
+
+  rule array_elements
+    inline_table_array | float_array | string_array | array_array | integer_array | datetime_array | bool_array
+  end
+
+  rule array_array
+    (array (space "," array_comments array)*) {
+      captures[:array].map(&:value)
+    }
   end
 
   rule toml_values

--- a/lib/toml-rb/grammars/primitive.citrus
+++ b/lib/toml-rb/grammars/primitive.citrus
@@ -2,7 +2,7 @@ grammar TomlRB::Primitive
   include TomlRB::Helper
 
   rule primitive
-    string | bool | datetime | number
+    datetime | bool | number | string
   end
 
   ##
@@ -66,15 +66,21 @@ grammar TomlRB::Primitive
   ##
 
   rule number
-     exponent | float | integer
+     float | integer
   end
 
   rule float
-    (integer '.' integer) { to_str.to_f }
+    exponential_float | fractional_float
   end
 
-  rule exponent
-    ( (float | integer) [eE] integer) { to_str.to_f }
+  rule exponential_float
+    ((fractional_float | integer) [eE] integer) { to_str.to_f }
+  end
+
+  rule fractional_float
+    (integer '.' [0-9_]+) { 
+      to_str.to_f
+    }
   end
 
   rule integer
@@ -106,7 +112,7 @@ grammar TomlRB::Primitive
   ##
 
   rule key
-    quoted_key | bare_key
+    dotted_key
   end
 
   rule bare_key
@@ -114,6 +120,16 @@ grammar TomlRB::Primitive
   end
 
   rule quoted_key
-    string
+    basic_string | literal_string 
+  end
+
+  rule single_key
+    quoted_key | bare_key
+  end
+
+  rule dotted_key
+    (space? single_key space?  ("." space? single_key space?)* ) {
+      captures[:single_key].map(&:value)
+    }
   end
 end

--- a/lib/toml-rb/inline_table.rb
+++ b/lib/toml-rb/inline_table.rb
@@ -1,72 +1,26 @@
 module TomlRB
   class InlineTable
-    attr_reader :symbolize_keys
-
     def initialize(keyvalue_pairs)
       @pairs = keyvalue_pairs
-      @symbolize_keys = false
-    end
-
-    def value(symbolize_keys = false)
-      if (@symbolize_keys = symbolize_keys)
-        tuple = ->(kv) { [kv.key.to_sym, visit_value(kv.value)] }
-      else
-        tuple = ->(kv) { [kv.key, visit_value(kv.value)] }
-      end
-
-      Hash[@pairs.map(&tuple)]
-    end
-
-    def visit_inline_table(inline_table)
-      result = {}
-
-      inline_table.value(@symbolize_keys).each do |k, v|
-        result[key k] = visit_value v
-      end
-
-      result
     end
 
     def accept_visitor(keyvalue)
-      keyvalue.visit_inline_table self
+      value keyvalue.symbolize_keys
     end
 
-    private
-
-    def visit_value(a_value)
-      return a_value unless a_value.respond_to? :accept_visitor
-
-      a_value.accept_visitor self
-    end
-
-    def key(a_key)
-      symbolize_keys ? a_key.to_sym : a_key
-    end
-  end
-
-  class InlineTableArray
-    def initialize(inline_tables)
-      @inline_tables = inline_tables
-    end
-
-    def value(symbolize_keys = false)
-      @inline_tables.map { |it| it.value(symbolize_keys) }
+    def value(symbolize_keys=false)
+      result = {}
+      @pairs.each do |kv|
+        update = kv.assign({}, symbolize_keys)
+        result.merge!(update) { |key, _, _| fail ValueOverwriteError.new(key) }
+      end
+      result
     end
   end
 
   module InlineTableParser
     def value
       TomlRB::InlineTable.new captures[:keyvalue].map(&:value)
-    end
-  end
-
-  module InlineTableArrayParser
-    def value
-      tables = captures[:inline_table_array_elements].map do |x|
-        x.captures[:inline_table]
-      end
-
-      TomlRB::InlineTableArray.new(tables.flatten.map(&:value)).value
     end
   end
 end

--- a/lib/toml-rb/parser.rb
+++ b/lib/toml-rb/parser.rb
@@ -25,8 +25,8 @@ module TomlRB
       @current = table_array.navigate_keys @hash, @symbolize_keys
     end
 
-    def visit_keygroup(keygroup)
-      @current = keygroup.navigate_keys @hash, @visited_keys, @symbolize_keys
+    def visit_table(table)
+      @current = table.navigate_keys @hash, @visited_keys, @symbolize_keys
     end
 
     def visit_keyvalue(keyvalue)

--- a/lib/toml-rb/table_array.rb
+++ b/lib/toml-rb/table_array.rb
@@ -1,35 +1,35 @@
 module TomlRB
   class TableArray
-    def initialize(nested_keys)
-      @nested_keys = nested_keys
+    def initialize(dotted_keys)
+      @dotted_keys = dotted_keys
     end
 
     def navigate_keys(hash, symbolize_keys = false)
-      last_key = @nested_keys.pop
-      last_key = last_key.to_sym if symbolize_keys
+      current = hash 
+      keys = symbolize_keys ? @dotted_keys.map(&:to_sym) : @dotted_keys
+      last_key = keys.pop
 
       # Go over the parent keys
-      @nested_keys.each do |key|
-        key = symbolize_keys ? key.to_sym : key
-        hash[key] = {} unless hash[key]
+      keys.each do |key|
+        current[key] = {} unless current[key]
 
-        if hash[key].is_a? Array
-          hash[key] << {} if hash[key].empty?
-          hash = hash[key].last
+        if current[key].is_a? Array
+          current[key] << {} if current[key].empty?
+          current = current[key].last
         else
-          hash = hash[key]
+          current = current[key]
         end
       end
 
       # Define Table Array
-      if hash[last_key].is_a? Hash
+      if current[last_key].is_a? Hash
         fail TomlRB::ParseError,
              "#{last_key} was defined as hash but is now redefined as a table!"
       end
-      hash[last_key] = [] unless hash[last_key]
-      hash[last_key] << {}
+      current[last_key] = [] unless current[last_key]
+      current[last_key] << {}
 
-      hash[last_key].last
+      current[last_key].last
     end
 
     def accept_visitor(parser)
@@ -37,14 +37,14 @@ module TomlRB
     end
 
     def full_key
-      @nested_keys.join('.')
+      @dotted_keys.join('.')
     end
   end
 
   # Used in document.citrus
   module TableArrayParser
     def value
-      TomlRB::TableArray.new(captures[:stripped_key].map(&:value))
+      TomlRB::TableArray.new(captures[:stripped_key].map(&:value).first)
     end
   end
 end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,14 +1,14 @@
 require_relative 'helper'
 
 class ErrorsTest < Minitest::Test
-  def test_text_after_keygroup
+  def test_text_after_table
     str = "[error] if you didn't catch this, your parser is broken"
     assert_raises(TomlRB::ParseError) { TomlRB.parse(str) }
   end
 
   def test_text_after_string
     str = 'string = "Anything other than tabs, spaces and newline after a '
-    str += 'keygroup or key value pair has ended should produce an error '
+    str += 'table or key value pair has ended should produce an error '
     str += 'unless it is a comment" like this'
 
     assert_raises(TomlRB::ParseError) { TomlRB.parse(str) }

--- a/test/hard_example.toml
+++ b/test/hard_example.toml
@@ -32,10 +32,10 @@ key3 = 'value'
 [[a.b]]
 c = 3
 
-# Each of the following keygroups/key value pairs should produce an error. Uncomment to them to test
+# Each of the following table/key value pairs should produce an error. Uncomment to them to test
 
 #[error]   if you didn't catch this, your parser is broken
-#string = "Anything other than tabs, spaces and newline after a keygroup or key value pair has ended should produce an error unless it is a comment"   like this
+#string = "Anything other than tabs, spaces and newline after a table or key value pair has ended should produce an error unless it is a comment"   like this
 #array = [
 #         "This might most likely happen in multiline arrays",
 #         Like here,

--- a/test/toml_examples.rb
+++ b/test/toml_examples.rb
@@ -26,7 +26,7 @@ class TomlRB::Examples
       },
       "string" => {
         "basic" => {
-          "basic" => "I'm a string. \"You can quote me\". Name\tJos\\u00E9\nLocation\tSF."
+          "basic" => "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
         },
         "multiline" => {
           "key1" => "One\nTwo",
@@ -41,15 +41,11 @@ class TomlRB::Examples
         "literal" => {
           "winpath" => "C:\\Users\\nodejs\\templates",
           "winpath2" => "\\\\ServerX\\admin$\\system32\\",
-          "quoted" => "Tom\"Dubs\"Preston-Werner",
+          "quoted" => "Tom \"Dubs\" Preston-Werner",
           "regex" => "<\\i\\c*\\s*>",
           "multiline" => {
-            "regex2" => "I[
-                dw
-            ]on'tneed\\d{
-                2
-            }apples",
-            "lines" => "Thefirstnewlineis\ntrimmedinrawstrings.\nAllotherwhitespace\nispreserved.\n"
+            "regex2" => "I [dw]on't need \\d{2} apples",
+            "lines" => "The first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n"
           }
         }
       },

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -8,13 +8,13 @@ class TomlTest < Minitest::Test
     parsed = TomlRB.load_file(path)
     hash = TomlRB::Examples.example_v_0_4_0
 
-    assert_equal hash['Array'], parsed['Array']
-    assert_equal hash['Booleans'], parsed['Booleans']
-    assert_equal hash['Datetime'], parsed['Datetime']
-    assert_equal hash['Float'], parsed['Float']
-    assert_equal hash['Integer'], parsed['Integer']
-    assert_equal hash['String'], parsed['String']
-    assert_equal hash['Table'], parsed['Table']
+    assert_equal hash['array'], parsed['array']
+    assert_equal hash['boolean'], parsed['boolean']
+    assert_equal hash['datetime'], parsed['datetime']
+    assert_equal hash['float'], parsed['float']
+    assert_equal hash['integer'], parsed['integer']
+    assert_equal hash['string'], parsed['string']
+    assert_equal hash['table'], parsed['table']
     assert_equal hash['products'], parsed['products']
     assert_equal hash['fruit'], parsed['fruit']
   end


### PR DESCRIPTION
Release [toml v0.5.0](https://github.com/toml-lang/toml/blob/master/CHANGELOG.md).
First, please support "dotted key".

Change points
- [x] Add dotted keys.
- [ ] Add hex, octal, and binary integer formats.
- [ ] Add special float values (inf, nan)
- [ ] Rename Datetime to Offset Date-Time.
- [ ] Add Local Date-Time.
- [ ] Add Local Date.
- [ ] Add Local Time.
- [ ] Allow space (instead of T) to separate date and time in Date-Time.
