### PR TITLE
Fix test warnings and assert_raise failures

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,2 +1,3 @@
+gem "minitest"
 require 'minitest/autorun'
 require_relative '../lib/toml-rb'

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -120,7 +120,8 @@ class TomlTest < Minitest::Test
       begin
         TomlRB.load_file(toml_file)
       rescue => e
-        assert e.class.ancestors.include?(TomlRB::Error), "Expected a subclass of TomlRB::Error, got #{e.class} for #{toml_file}"
+        message = "Expected TomlRB::Error, got #{e.class} for #{toml_file}"
+        assert e.class.ancestors.include?(TomlRB::Error), message
       end
     end
   end

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -117,8 +117,10 @@ class TomlTest < Minitest::Test
   def test_invalid_cases
     file = '*'
     Dir["test/examples/invalid/#{file}.toml"].each do |toml_file|
-      assert_raises(TomlRB::Error, "For file #{toml_file}") do
+      begin
         TomlRB.load_file(toml_file)
+      rescue => e
+        assert e.class.ancestors.include?(TomlRB::Error), "Expected a subclass of TomlRB::Error, but #{e.class} was raised for #{toml_file}"
       end
     end
   end

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -120,7 +120,7 @@ class TomlTest < Minitest::Test
       begin
         TomlRB.load_file(toml_file)
       rescue => e
-        assert e.class.ancestors.include?(TomlRB::Error), "Expected a subclass of TomlRB::Error, but #{e.class} was raised for #{toml_file}"
+        assert e.class.ancestors.include?(TomlRB::Error), "Expected a subclass of TomlRB::Error, got #{e.class} for #{toml_file}"
       end
     end
   end


### PR DESCRIPTION
Method assert_raises() does not work with error subclasses. Used workaround from https://stackoverflow.com/questions/20617670/how-to-get-assert-raise-to-handle-exception-subclasses

Added gem "minitest" as suggested by rake warnings. 