### PR TITLE
Fix dumping of #@ and #{

### DIFF
--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -88,7 +88,7 @@ module TomlRB
       if obj.is_a? Time
         obj.strftime('%Y-%m-%dT%H:%M:%SZ')
       elsif obj.is_a? String
-        obj.inspect.gsub(/\\#\@/, '#@').gsub(/\\#\{/, '#{')
+        obj.inspect.gsub(/\\(#[@{])/, '\1')
       else
         obj.inspect
       end

--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -88,7 +88,7 @@ module TomlRB
       if obj.is_a? Time
         obj.strftime('%Y-%m-%dT%H:%M:%SZ')
       elsif obj.is_a? String
-        obj.inspect.gsub(/\\#\@/,'#@').gsub(/\\#\{/,'#{')
+        obj.inspect.gsub(/\\#\@/, '#@').gsub(/\\#\{/, '#{')
       else
         obj.inspect
       end

--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -87,6 +87,8 @@ module TomlRB
     def to_toml(obj)
       if obj.is_a? Time
         obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+      elsif obj.is_a? String
+        obj.inspect.gsub(/\\#\@/,'#@').gsub(/\\#\{/,'#{')
       else
         obj.inspect
       end

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -93,13 +93,13 @@ class DumperTest < Minitest::Test
   end
 
   def test_dump_interpolation_curly
-    hash = {"key" => 'includes #{variable}'}
+    hash = { "key" => 'includes #{variable}' }
     dumped = TomlRB.dump(hash)
     assert_equal "key = \"includes \#{variable}\"\n", dumped
   end
 
   def test_dump_interpolation_at
-    hash = {"key" => 'includes #@variable'}
+    hash = { "key" => 'includes #@variable' }
     dumped = TomlRB.dump(hash)
     assert_equal "key = \"includes \#@variable\"\n", dumped
   end

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -91,4 +91,16 @@ class DumperTest < Minitest::Test
 
     assert_equal toml, dumped
   end
+
+  def test_dump_interpolation_curly
+    hash = {"key" => 'includes #{variable}'}
+    dumped = TomlRB.dump(hash)
+    assert_equal "key = \"includes \#{variable}\"\n", dumped
+  end
+
+  def test_dump_interpolation_at
+    hash = {"key" => 'includes #@variable'}
+    dumped = TomlRB.dump(hash)
+    assert_equal "key = \"includes \#@variable\"\n", dumped
+  end
 end

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -95,7 +95,7 @@ class DumperTest < Minitest::Test
   def test_dump_interpolation_curly
     hash = { "key" => 'includes #{variable}' }
     dumped = TomlRB.dump(hash)
-    assert_equal  'key = "includes #{variable}"' + "\n", dumped
+    assert_equal 'key = "includes #{variable}"' + "\n", dumped
   end
 
   def test_dump_interpolation_at

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -95,12 +95,12 @@ class DumperTest < Minitest::Test
   def test_dump_interpolation_curly
     hash = { "key" => 'includes #{variable}' }
     dumped = TomlRB.dump(hash)
-    assert_equal "key = \"includes \#{variable}\"\n", dumped
+    assert_equal  'key = "includes #{variable}"' + "\n", dumped
   end
 
   def test_dump_interpolation_at
     hash = { "key" => 'includes #@variable' }
     dumped = TomlRB.dump(hash)
-    assert_equal "key = \"includes \#@variable\"\n", dumped
+    assert_equal 'key = "includes #@variable"' + "\n", dumped
   end
 end


### PR DESCRIPTION
Dumping '#@' and '#{' produces invalid TOML, because '#@'.inspect introduces a single backslash before #.