### PR TITLE
Add dumping of regexp as string

### DIFF
--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -87,6 +87,8 @@ module TomlRB
     def to_toml(obj)
       if obj.is_a? Time
         obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+      elsif obj.is_a? Regexp
+        obj.inspect.inspect
       else
         obj.inspect
       end

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -30,6 +30,9 @@ class DumperTest < Minitest::Test
 
     dumped = TomlRB.dump(datetime: Time.utc(1986, 8, 28, 15, 15))
     assert_equal("datetime = 1986-08-28T15:15:00Z\n", dumped)
+
+    dumped = TomlRB.dump(regexp: /abc\n*\{/)
+    assert_equal("regexp = \"/abc\\\\n*\\\\{/\"\n", dumped)
   end
 
   def test_dump_nested_attributes


### PR DESCRIPTION
As described in the issue - if people want to dump Regexp, let them. Can't use .source though, as it can introduce invalid escape sequences in resulting TOML.