### PR TITLE
Support toml v0.5.0

### DIFF
--- a/lib/toml-rb.rb
+++ b/lib/toml-rb.rb
@@ -3,6 +3,7 @@ require 'citrus'
 require_relative "toml-rb/errors"
 require_relative "toml-rb/array"
 require_relative "toml-rb/string"
+require_relative "toml-rb/datetime"
 require_relative "toml-rb/table"
 require_relative "toml-rb/table_array"
 require_relative "toml-rb/inline_table"

--- a/lib/toml-rb.rb
+++ b/lib/toml-rb.rb
@@ -3,10 +3,10 @@ require 'citrus'
 require_relative "toml-rb/errors"
 require_relative "toml-rb/array"
 require_relative "toml-rb/string"
+require_relative "toml-rb/table"
 require_relative "toml-rb/table_array"
 require_relative "toml-rb/inline_table"
 require_relative "toml-rb/keyvalue"
-require_relative "toml-rb/keygroup"
 require_relative "toml-rb/parser"
 require_relative "toml-rb/dumper"
 

--- a/lib/toml-rb/array.rb
+++ b/lib/toml-rb/array.rb
@@ -1,14 +1,8 @@
 module TomlRB
   module ArrayParser
     def value
-      elements = captures[:elements].first
-      return [] unless elements
-
-      if elements.captures.key? :string
-        elements.captures[:string].map(&:value)
-      else
-        eval(to_str)
-      end
+      elements = captures[:array_elements].first
+      return elements ? elements.value : []
     end
   end
 end

--- a/lib/toml-rb/datetime.rb
+++ b/lib/toml-rb/datetime.rb
@@ -1,0 +1,38 @@
+module TomlRB
+  module OffsetDateTimeParser
+    def value
+      skeleton = captures[:datetime_skeleton].first
+      year, mon, day, hour, min, sec, sec_frac = skeleton.value
+      offset = captures[:date_offset].first || "+00:00"
+      sec = "#{sec}.#{sec_frac}".to_f
+
+      Time.new(year, mon, day, hour, min, sec, offset.to_s)
+    end
+  end
+
+  module LocalDateTimeParser
+    def value
+      year, mon, day = captures[:date_skeleton].first.value
+      hour, min, sec, sec_frac = captures[:time_skeleton].first.value
+      usec = sec_frac.to_s.ljust(6, '0')
+
+      Time.local(year, mon, day, hour, min, sec, usec)
+    end
+  end
+
+  module LocalDateParser
+    def value
+      year, mon, day = captures[:date_skeleton].first.value
+      Time.local(year,mon,day)
+    end
+  end
+
+  module LocalTimeParser
+    def value
+      hour, min, sec, sec_frac = captures[:time_skeleton].first.value
+      usec = sec_frac.to_s.ljust(6, '0')
+
+      Time.at(3600 * hour.to_i + 60 * min.to_i + sec.to_i, usec.to_i)
+    end
+  end
+end

--- a/lib/toml-rb/grammars/array.citrus
+++ b/lib/toml-rb/grammars/array.citrus
@@ -1,39 +1,38 @@
 grammar TomlRB::Arrays
   include TomlRB::Primitive
 
-  rule array
-    ("[" array_comments (elements)? space ","? array_comments "]" indent?) <TomlRB::ArrayParser>
-  end
-
+  
   rule array_comments
     (indent? (comment indent?)*)
   end
 
-  rule elements
-    float_array | string_array | array_array | integer_array | datetime_array | bool_array
-  end
-
   rule float_array
-    ((exponent | float) (space "," array_comments (exponent | float))*)
+    (float (space "," array_comments float)*) {
+      captures[:float].map(&:value)
+    }
   end
 
   rule string_array
-    (string (space "," array_comments string)*)
-  end
-
-  rule array_array
-    (array (space "," array_comments array)*)
+    (string (space "," array_comments string)*) {
+      captures[:string].map(&:value)
+    }
   end
 
   rule integer_array
-    (integer (space "," array_comments integer)*)
+    (integer (space "," array_comments integer)*) {
+      captures[:integer].map(&:value)
+    }
   end
 
   rule datetime_array
-    (datetime (space "," array_comments datetime)*)
+    (datetime (space "," array_comments datetime)*) {
+      captures[:datetime].map(&:value)
+    }
   end
 
   rule bool_array
-    (bool (space "," array_comments bool)*)
+    (bool (space "," array_comments bool)*) {
+      captures[:bool].map(&:value)
+    }
   end
 end

--- a/lib/toml-rb/grammars/array.citrus
+++ b/lib/toml-rb/grammars/array.citrus
@@ -1,6 +1,5 @@
 grammar TomlRB::Arrays
   include TomlRB::Primitive
-
   
   rule array_comments
     (indent? (comment indent?)*)

--- a/lib/toml-rb/grammars/document.citrus
+++ b/lib/toml-rb/grammars/document.citrus
@@ -3,15 +3,15 @@ grammar TomlRB::Document
   include TomlRB::Arrays
 
   rule document
-    (comment | table_array | keygroup | keyvalue | line_break)*
+    (comment | table_array | table | keyvalue | line_break)*
   end
 
   rule table_array
     (space? '[[' stripped_key ("." stripped_key)* ']]' comment?) <TomlRB::TableArrayParser>
   end
 
-  rule keygroup
-    (space? '[' stripped_key ("." stripped_key)* ']' comment?) <TomlRB::KeygroupParser>
+  rule table
+    (space? '[' stripped_key ("." stripped_key)* ']' comment?) <TomlRB::TableParser>
   end
 
   rule keyvalue
@@ -19,15 +19,27 @@ grammar TomlRB::Document
   end
 
   rule inline_table
-    (space? '{' (keyvalue (',' keyvalue)*)? space? '}' ) <TomlRB::InlineTableParser>
+    (space? '{' (keyvalue? (',' keyvalue)*)? space? '}' ) <TomlRB::InlineTableParser>
   end
 
   rule inline_table_array
-    ("[" array_comments inline_table_array_elements space ","? array_comments "]" indent?) <TomlRB::InlineTableArrayParser>
+    (inline_table (space "," array_comments inline_table)*) {
+      captures[:inline_table].map(&:value).map(&:value)
+    }
   end
 
-  rule inline_table_array_elements
-    (inline_table (space "," array_comments inline_table)*)
+  rule array
+    ("[" array_comments (array_elements)? space ","? array_comments "]" indent?) <TomlRB::ArrayParser>
+  end
+
+  rule array_elements
+    inline_table_array | float_array | string_array | array_array | integer_array | datetime_array | bool_array
+  end
+
+  rule array_array
+    (array (space "," array_comments array)*) {
+      captures[:array].map(&:value)
+    }
   end
 
   rule toml_values

--- a/lib/toml-rb/grammars/document.citrus
+++ b/lib/toml-rb/grammars/document.citrus
@@ -7,11 +7,11 @@ grammar TomlRB::Document
   end
 
   rule table_array
-    (space? '[[' stripped_key ("." stripped_key)* ']]' comment?) <TomlRB::TableArrayParser>
+    (space? '[[' stripped_key ']]' comment?) <TomlRB::TableArrayParser>
   end
 
   rule table
-    (space? '[' stripped_key ("." stripped_key)* ']' comment?) <TomlRB::TableParser>
+    (space? '[' stripped_key ']' comment?) <TomlRB::TableParser>
   end
 
   rule keyvalue

--- a/lib/toml-rb/grammars/primitive.citrus
+++ b/lib/toml-rb/grammars/primitive.citrus
@@ -34,31 +34,45 @@ grammar TomlRB::Primitive
   ##
 
   rule datetime
-    ( skeleton:(datetime_skeleton | date_skeleton) ("Z" | date_offset | [,\.] frac:(/\d/1*6) date_offset?)? ) {
-      skeleton = captures[:skeleton].first
-      y,m,d,h,mi,s = skeleton.value
-      offset = captures[:date_offset].first || "+00:00"
-      sec_frac = captures[:frac].first || 0
-      s = "#{s}.#{sec_frac}".to_f
+    offset_datetime | local_datetime | local_date | local_time
+  end
 
-      Time.new(*[y,m,d,h,mi,s,offset.to_s])
-    }
+  rule offset_datetime
+    ( skeleton:datetime_skeleton ("Z" | date_offset) ) <TomlRB::OffsetDateTimeParser>
+  end
+
+  rule local_datetime
+    datetime_skeleton <TomlRB::LocalDateTimeParser>
+  end
+
+  rule local_date
+    (date_skeleton space) <TomlRB::LocalDateParser>
+  end
+
+  rule local_time
+    (time_skeleton space) <TomlRB::LocalTimeParser>
   end
 
   rule datetime_skeleton
-    (y:/\d\d\d\d/ "-" m:/\d\d/ "-" d:/\d\d/ "T" h:/\d\d/ ":" mi:/\d\d/ ":" s:/\d\d/) {
-      [:y,:m,:d,:h,:mi,:s].map{ |s| capture(s).value }
+    (date_skeleton ("T"|" ") time_skeleton) {
+      capture(:date_skeleton).value + capture(:time_skeleton).value
+    }
+  end
+
+  rule date_skeleton
+    (year:/\d\d\d\d/ "-" mon:/\d\d/ "-" day:/\d\d/) {
+      [:year,:mon,:day].map{ |s| capture(s).value }
+    }
+  end
+
+  rule time_skeleton
+    ( hour:([0-2][0-9]) ":" mim:([0-6][0-9]) ":" sec:([0-6][0-9])  ([,\.] sec_frac:(/\d/1*6))? ) {
+      [:hour,:mim,:sec].map{ |s| capture(s).value } + [capture(:sec_frac) || '0']
     }
   end
 
   rule date_offset
     offset:(sign /\d\d/ ":" /\d\d/)
-  end
-
-  rule date_skeleton
-    (y:/\d\d\d\d/ "-" m:/\d\d/ "-" d:/\d\d/) {
-      [:y,:m,:d].map{ |s| capture(s).value } + [0, 0, 0]
-    }
   end
 
   ##

--- a/lib/toml-rb/grammars/primitive.citrus
+++ b/lib/toml-rb/grammars/primitive.citrus
@@ -2,7 +2,7 @@ grammar TomlRB::Primitive
   include TomlRB::Helper
 
   rule primitive
-    string | bool | datetime | number
+    datetime | bool | number | string
   end
 
   ##
@@ -66,15 +66,21 @@ grammar TomlRB::Primitive
   ##
 
   rule number
-     exponent | float | integer
+     float | integer
   end
 
   rule float
-    (integer '.' integer) { to_str.to_f }
+    exponential_float | fractional_float
   end
 
-  rule exponent
-    ( (float | integer) [eE] integer) { to_str.to_f }
+  rule exponential_float
+    ((fractional_float | integer) [eE] integer) { to_str.to_f }
+  end
+
+  rule fractional_float
+    (integer '.' [0-9_]+) { 
+      to_str.to_f
+    }
   end
 
   rule integer
@@ -106,7 +112,7 @@ grammar TomlRB::Primitive
   ##
 
   rule key
-    quoted_key | bare_key
+    dotted_key
   end
 
   rule bare_key
@@ -114,6 +120,16 @@ grammar TomlRB::Primitive
   end
 
   rule quoted_key
-    string
+    basic_string | literal_string 
+  end
+
+  rule single_key
+    quoted_key | bare_key
+  end
+
+  rule dotted_key
+    (space? single_key space?  ("." space? single_key space?)* ) {
+      captures[:single_key].map(&:value)
+    }
   end
 end

--- a/lib/toml-rb/grammars/primitive.citrus
+++ b/lib/toml-rb/grammars/primitive.citrus
@@ -70,7 +70,18 @@ grammar TomlRB::Primitive
   end
 
   rule float
-    exponential_float | fractional_float
+    inf | nan | exponential_float | fractional_float
+  end
+
+  rule inf
+    (s:sign? 'inf') {
+      sign = (capture(:s).value != '-') ? 1 : -1
+      sign * Float::INFINITY
+    }
+  end
+
+  rule nan
+    (sign? 'nan') { Float::NAN }
   end
 
   rule exponential_float

--- a/lib/toml-rb/grammars/primitive.citrus
+++ b/lib/toml-rb/grammars/primitive.citrus
@@ -66,7 +66,7 @@ grammar TomlRB::Primitive
   ##
 
   rule number
-     float | integer
+    float | integer
   end
 
   rule float
@@ -74,16 +74,32 @@ grammar TomlRB::Primitive
   end
 
   rule exponential_float
-    ((fractional_float | integer) [eE] integer) { to_str.to_f }
+    ((fractional_float | demical_integer) [eE] demical_integer) { to_str.to_f }
   end
 
   rule fractional_float
-    (integer '.' [0-9_]+) { 
+    (demical_integer '.' [0-9_]+) { 
       to_str.to_f
     }
   end
 
   rule integer
+    hexadecimal_integer | octal_integer | binary_integer | demical_integer
+  end
+
+  rule hexadecimal_integer
+    ('0x' [a-fA-F0-9_]+) { to_str.to_i(16) }
+  end
+
+  rule octal_integer
+    ('0o' [0-7_]+) { to_str.to_i(8) }
+  end
+
+  rule binary_integer
+    ('0b' [01_]+) { to_str.to_i(2) }
+  end
+
+  rule demical_integer
     (sign? [0-9_]+) { to_str.to_i }
   end
 

--- a/lib/toml-rb/inline_table.rb
+++ b/lib/toml-rb/inline_table.rb
@@ -1,72 +1,26 @@
 module TomlRB
   class InlineTable
-    attr_reader :symbolize_keys
-
     def initialize(keyvalue_pairs)
       @pairs = keyvalue_pairs
-      @symbolize_keys = false
-    end
-
-    def value(symbolize_keys = false)
-      if (@symbolize_keys = symbolize_keys)
-        tuple = ->(kv) { [kv.key.to_sym, visit_value(kv.value)] }
-      else
-        tuple = ->(kv) { [kv.key, visit_value(kv.value)] }
-      end
-
-      Hash[@pairs.map(&tuple)]
-    end
-
-    def visit_inline_table(inline_table)
-      result = {}
-
-      inline_table.value(@symbolize_keys).each do |k, v|
-        result[key k] = visit_value v
-      end
-
-      result
     end
 
     def accept_visitor(keyvalue)
-      keyvalue.visit_inline_table self
+      value keyvalue.symbolize_keys
     end
 
-    private
-
-    def visit_value(a_value)
-      return a_value unless a_value.respond_to? :accept_visitor
-
-      a_value.accept_visitor self
-    end
-
-    def key(a_key)
-      symbolize_keys ? a_key.to_sym : a_key
-    end
-  end
-
-  class InlineTableArray
-    def initialize(inline_tables)
-      @inline_tables = inline_tables
-    end
-
-    def value(symbolize_keys = false)
-      @inline_tables.map { |it| it.value(symbolize_keys) }
+    def value(symbolize_keys=false)
+      result = {}
+      @pairs.each do |kv|
+        update = kv.assign({}, symbolize_keys)
+        result.merge!(update) { |key, _, _| fail ValueOverwriteError.new(key) }
+      end
+      result
     end
   end
 
   module InlineTableParser
     def value
       TomlRB::InlineTable.new captures[:keyvalue].map(&:value)
-    end
-  end
-
-  module InlineTableArrayParser
-    def value
-      tables = captures[:inline_table_array_elements].map do |x|
-        x.captures[:inline_table]
-      end
-
-      TomlRB::InlineTableArray.new(tables.flatten.map(&:value)).value
     end
   end
 end

--- a/lib/toml-rb/inline_table.rb
+++ b/lib/toml-rb/inline_table.rb
@@ -11,7 +11,7 @@ module TomlRB
     def value(symbolize_keys=false)
       result = {}
       @pairs.each do |kv|
-        update = kv.assign({}, symbolize_keys)
+        update = kv.assign({}, [], symbolize_keys)
         result.merge!(update) { |key, _, _| fail ValueOverwriteError.new(key) }
       end
       result

--- a/lib/toml-rb/keyvalue.rb
+++ b/lib/toml-rb/keyvalue.rb
@@ -10,8 +10,8 @@ module TomlRB
 
     def assign(hash, symbolize_keys = false)
       @symbolize_keys = symbolize_keys
-      @dotted_keys = symbolize_keys ? @dotted_keys.map(&:to_sym) : @dotted_keys
-      update = @dotted_keys.reverse.inject(visit_value @value) { |k1, k2| { k2 => k1 } }
+      keys = symbolize_keys ? @dotted_keys.map(&:to_sym) : @dotted_keys
+      update = keys.reverse.inject(visit_value @value) { |k1, k2| { k2 => k1 } }
       hash.merge!(update) { |key, _, _| fail ValueOverwriteError.new(key) }
     end
 

--- a/lib/toml-rb/parser.rb
+++ b/lib/toml-rb/parser.rb
@@ -25,8 +25,8 @@ module TomlRB
       @current = table_array.navigate_keys @hash, @symbolize_keys
     end
 
-    def visit_keygroup(keygroup)
-      @current = keygroup.navigate_keys @hash, @visited_keys, @symbolize_keys
+    def visit_table(table)
+      @current = table.navigate_keys @hash, @visited_keys, @symbolize_keys
     end
 
     def visit_keyvalue(keyvalue)

--- a/lib/toml-rb/parser.rb
+++ b/lib/toml-rb/parser.rb
@@ -5,6 +5,7 @@ module TomlRB
     def initialize(content, options = {})
       @hash = {}
       @visited_keys = []
+      @fully_defined_keys = []
       @current = @hash
       @symbolize_keys = options[:symbolize_keys]
 
@@ -19,6 +20,7 @@ module TomlRB
     # Read about the Visitor pattern
     # http://en.wikipedia.org/wiki/Visitor_pattern
     def visit_table_array(table_array)
+      @fully_defined_keys = []
       table_array_key = table_array.full_key
       @visited_keys.reject! { |k| k.start_with? table_array_key }
 
@@ -26,11 +28,12 @@ module TomlRB
     end
 
     def visit_table(table)
+      @fully_defined_keys = []
       @current = table.navigate_keys @hash, @visited_keys, @symbolize_keys
     end
 
     def visit_keyvalue(keyvalue)
-      keyvalue.assign @current, @symbolize_keys
+      keyvalue.assign @current, @fully_defined_keys, @symbolize_keys
     end
   end
 end

--- a/lib/toml-rb/table_array.rb
+++ b/lib/toml-rb/table_array.rb
@@ -1,35 +1,35 @@
 module TomlRB
   class TableArray
-    def initialize(nested_keys)
-      @nested_keys = nested_keys
+    def initialize(dotted_keys)
+      @dotted_keys = dotted_keys
     end
 
     def navigate_keys(hash, symbolize_keys = false)
-      last_key = @nested_keys.pop
-      last_key = last_key.to_sym if symbolize_keys
+      current = hash 
+      keys = symbolize_keys ? @dotted_keys.map(&:to_sym) : @dotted_keys
+      last_key = keys.pop
 
       # Go over the parent keys
-      @nested_keys.each do |key|
-        key = symbolize_keys ? key.to_sym : key
-        hash[key] = {} unless hash[key]
+      keys.each do |key|
+        current[key] = {} unless current[key]
 
-        if hash[key].is_a? Array
-          hash[key] << {} if hash[key].empty?
-          hash = hash[key].last
+        if current[key].is_a? Array
+          current[key] << {} if current[key].empty?
+          current = current[key].last
         else
-          hash = hash[key]
+          current = current[key]
         end
       end
 
       # Define Table Array
-      if hash[last_key].is_a? Hash
+      if current[last_key].is_a? Hash
         fail TomlRB::ParseError,
              "#{last_key} was defined as hash but is now redefined as a table!"
       end
-      hash[last_key] = [] unless hash[last_key]
-      hash[last_key] << {}
+      current[last_key] = [] unless current[last_key]
+      current[last_key] << {}
 
-      hash[last_key].last
+      current[last_key].last
     end
 
     def accept_visitor(parser)
@@ -37,14 +37,14 @@ module TomlRB
     end
 
     def full_key
-      @nested_keys.join('.')
+      @dotted_keys.join('.')
     end
   end
 
   # Used in document.citrus
   module TableArrayParser
     def value
-      TomlRB::TableArray.new(captures[:stripped_key].map(&:value))
+      TomlRB::TableArray.new(captures[:stripped_key].map(&:value).first)
     end
   end
 end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,14 +1,14 @@
 require_relative 'helper'
 
 class ErrorsTest < Minitest::Test
-  def test_text_after_keygroup
+  def test_text_after_table
     str = "[error] if you didn't catch this, your parser is broken"
     assert_raises(TomlRB::ParseError) { TomlRB.parse(str) }
   end
 
   def test_text_after_string
     str = 'string = "Anything other than tabs, spaces and newline after a '
-    str += 'keygroup or key value pair has ended should produce an error '
+    str += 'table or key value pair has ended should produce an error '
     str += 'unless it is a comment" like this'
 
     assert_raises(TomlRB::ParseError) { TomlRB.parse(str) }

--- a/test/example-v0.5.0.toml
+++ b/test/example-v0.5.0.toml
@@ -1,0 +1,344 @@
+[keys]
+# Bare keys may only contain ASCII letters, ASCII digits,
+# underscores, and dashes (A-Za-z0-9_-).
+# Note that bare keys are allowed to be composed of only ASCII digits,
+# e.g. 1234, but are always interpreted as strings.
+key = "value"
+bare_key = "value"
+bare-key = "value"
+1234 = "value"
+
+# Quoted keys follow the exact same rules as either basic strings
+# or literal strings and allow you to use a much broader set of key names.
+# Best practice is to use bare keys except when absolutely necessary.
+"127.0.0.1" = "value"
+"character encoding" = "value"
+"ʎǝʞ" = "value"
+'key2' = "value"
+'quoted "value"' = "value"
+
+# Dotted keys are a sequence of bare or quoted keys joined with a dot.
+# This allows for grouping similar properties together:
+name = "Orange"
+physical.color = "orange"
+physical.shape = "round"
+site."google.com" = true
+
+# Since bare keys are allowed to compose of only ASCII integers,
+# it is possible to write dotted keys that look like floats
+# but are 2-part dotted keys.
+# Don't do this unless you have a good reason to (you probably don't).
+3.14159 = "pi"
+
+# As long as a key hasn't been directly defined,
+# you may still write to it and to names within it.
+a.b.c = 1
+a.d = 2
+
+# Defining dotted keys out-of-order is discouraged.
+# VALID BUT DISCOURAGED
+a.type = ''
+b.type = ''
+
+a.name = ''
+b.name = ''
+
+a.data = ''
+b.data = ''
+
+[string]
+# Multi-line basic strings are surrounded by three quotation marks
+# on each side and allow newlines.
+# A newline immediately following the opening delimiter will be trimmed.
+# All other whitespace and newline characters remain intact.
+str1 = """
+Roses are red
+Violets are blue"""
+
+# On a Unix system, the above multi-line string will most likely be the same as:
+str2 = "Roses are red\nViolets are blue"
+
+# On a Windows system, it will most likely be equivalent to:
+str3 = "Roses are red\r\nViolets are blue"
+
+# All of the escape sequences that are valid for basic strings are
+# also valid for multi-line basic strings.
+same.str1 = "The quick brown fox jumps over the lazy dog."
+
+same.str2 = """
+The quick brown \
+
+
+  fox jumps over \
+    the lazy dog."""
+
+same.str3 = """\
+       The quick brown \
+       fox jumps over \
+       the lazy dog.\
+       """
+
+# Literal strings are surrounded by single quotes.
+# Like basic strings, they must appear on a single line:
+winpath  = 'C:\Users\nodejs\templates'
+winpath2 = '\\ServerX\admin$\system32\'
+quoted   = 'Tom "Dubs" Preston-Werner'
+regex    = '<\i\c*\s*>'
+
+# Multi-line literal strings are surrounded by three single quotes
+# on each side and allow newlines. Like literal strings,
+# there is no escaping whatsoever.
+# A newline immediately following the opening delimiter will be trimmed.
+# All other content between the delimiters is
+# interpreted as-is without modification.
+regex2 = '''I [dw]on't need \d{2} apples'''
+lines  = '''
+The first newline is
+trimmed in raw strings.
+   All other whitespace
+   is preserved.
+'''
+
+[integer]
+# Integers are whole numbers. 
+# Positive numbers may be prefixed with a plus sign.
+# Negative numbers are prefixed with a minus sign.
+int1 = +99
+int2 = 42
+int3 = 0
+int4 = -17
+
+# For large numbers, you may use underscores between digits
+# to enhance readability.
+# Each underscore must be surrounded by at least one digit on each side.
+int5 = 1_000
+int6 = 5_349_221
+int7 = 1_2_3_4_5
+
+# Non-negative integer values may also be expressed
+# in hexadecimal, octal, or binary.
+# In these formats, leading + is not allowed and leading zeros are
+# allowed (after the prefix).
+# Hex values are case insensitive. 
+# Underscores are allowed between digits
+# (but not between the prefix and the value).
+
+# hexadecimal with prefix `0x`
+hex1 = 0xDEADBEEF
+hex2 = 0xdeadbeef
+hex3 = 0xdead_beef
+
+# octal with prefix `0o`
+oct1 = 0o01234567
+oct2 = 0o755 # useful for Unix file permissions
+
+# binary with prefix `0b`
+bin1 = 0b11010110
+
+[float]
+# Floats should be implemented as IEEE 754 binary64 values.
+
+# A float consists of an integer part
+# (which follows the same rules as decimal integer values) followed
+# by a fractional part and/or an exponent part.
+# If both a fractional part and exponent part are present,
+# the fractional part must precede the exponent part.
+
+# fractional
+flt1 = +1.0
+flt2 = 3.1415
+flt3 = -0.01
+
+# exponent
+flt4 = 5e+22
+flt5 = 1e06
+flt6 = -2E-2
+
+# both
+flt7 = 6.626e-34
+
+# Similar to integers, you may use underscores to enhance readability.
+# Each underscore must be surrounded by at least one digit.
+flt8 = 224_617.445_991_228
+
+# Float values -0.0 and +0.0 are valid and should map according to IEEE 754.
+flt9 = -0.0
+flt10 = +0.0
+
+# Special float values can also be expressed. They are always lowercase.
+
+# infinity
+sf1 = inf  # positive infinity
+sf2 = +inf # positive infinity
+sf3 = -inf # negative infinity
+
+# not a number
+sf4 = nan  # actual sNaN/qNaN encoding is implementation specific
+sf5 = +nan # same as `nan`
+sf6 = -nan # valid, actual encoding is implementation specific
+
+[boolean]
+# Booleans are just the tokens you're used to. Always lowercase.
+bool1 = true
+bool2 = false
+
+[offset-date-time]
+# To unambiguously represent a specific instant in time,
+# you may use an RFC 3339 formatted date-time with offset.
+odt1 = 1979-05-27T07:32:00Z
+odt2 = 1979-05-27T00:32:00-07:00
+odt3 = 1979-05-27T00:32:00.999999-07:00
+
+# For the sake of readability, you may replace the T delimiter
+# between date and time with a space (as permitted by RFC 3339 section 5.6).
+odt4 = 1979-05-27 07:32:00Z
+
+[local-date-time]
+# If you omit the offset from an RFC 3339 formatted date-time,
+# it will represent the given date-time without any relation
+# to an offset or timezone.
+# It cannot be converted to an instant in time without additional information.
+# Conversion to an instant, if required, is implementation specific.
+ldt1 = 1979-05-27T07:32:00
+ldt2 = 1979-05-27T00:32:00.999999
+
+[local-date]
+# If you include only the date portion of an RFC 3339 formatted date-time,
+# it will represent that entire day without any relation
+# to an offset or timezone.
+ld1 = 1979-05-27
+
+[local-time]
+# If you include only the time portion of an RFC 3339 formatted date-time,
+# it will represent that time of day without any relation to a specific day
+# or any offset or timezone.
+lt1 = 07:32:00
+lt2 = 00:32:00.999999
+
+[array]
+# Arrays are square brackets with values inside.
+# Whitespace is ignored. Elements are separated by commas.
+# Data types may not be mixed (different ways to define strings
+# should be considered the same type,
+# and so should arrays with different element types).
+arr1 = [ 1, 2, 3 ]
+arr2 = [ "red", "yellow", "green" ]
+arr3 = [ [ 1, 2 ], [3, 4, 5] ]
+arr4 = [ "all", 'strings', """are the same""", '''type''']
+arr5 = [ [ 1, 2 ], ["a", "b", "c"] ]
+
+# Arrays can also be multiline.
+# A terminating comma (also called trailing comma) is
+# ok after the last value of the array.
+# There can be an arbitrary number of newlines and comments
+# before a value and before the closing bracket.
+arr7 = [
+  1, 2, 3
+]
+arr8 = [
+  1,
+  2, # this is ok
+]
+
+[table]
+# Tables (also known as hash tables or dictionaries) are
+# collections of key/value pairs.
+# They appear in square brackets on a line by themselves.
+# You can tell them apart from arrays because arrays are only ever values.
+
+# Under that, and until the next table or EOF are the key/values of that table.
+# Key/value pairs within tables are not guaranteed to be in any specific order.
+
+[table.table-1]
+key1 = "some string"
+key2 = 123
+
+[table.table-2]
+key1 = "another string"
+key2 = 456
+
+# Naming rules for tables are the same as for keys (see definition of Keys above).
+[table.dog."tater.man"]
+type.name = "pug"
+
+# Whitespace around the key is ignored, however, best practice is to not use any extraneous whitespace.
+[table.a.b.c]            # this is best practice
+[ table.d.e.f ]          # same as [d.e.f]
+[ table . g .  h  . i ]    # same as [g.h.i]
+[ table . j . "ʞ" . 'l' ]  # same as [j."ʞ".'l']
+
+# You don't need to specify all the super-tables if you don't want to.
+# TOML knows how to do it for you.
+
+# [x] you
+# [x.y] don't
+# [x.y.z] need these
+[table.x.y.z.w] # for this to work
+
+[table.x] # defining a super-table afterwards is ok
+
+# Defining tables out-of-order is discouraged.
+
+# VALID BUT DISCOURAGED
+[table.a.x]
+[table.b]
+[table.a.y]
+
+# Dotted keys define everything to the left of each dot as a table.
+# Since tables cannot be defined more than once,
+# redefining such tables using a [table] header is not allowed.
+# Likewise, using dotted keys to redefine tables already defined
+# in [table] form is not allowed.
+
+# The [table] form can, however,
+# be used to define sub-tables within tables defined via dotted keys.
+[table.fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+# [table.fruit.apple]  # INVALID
+# [table.fruit.apple.taste]  # INVALID
+
+[table.fruit.apple.texture]  # you can add sub-tables
+smooth = true
+
+[inline-table]
+# Inline tables provide a more compact syntax for expressing tables.
+name = { first = "Tom", last = "Preston-Werner" }
+point = { x = 1, y = 2 }
+animal = { type.name = "pug" }
+
+
+[array-of-tables]
+# Array of Tables are inserted in the order encountered.
+# A double bracketed table without any key/value pairs
+# will be considered an empty table.
+[[array-of-tables.products]]
+name = "Hammer"
+sku = 738594937
+
+[[array-of-tables.products]]
+
+[[array-of-tables.products]]
+name = "Nail"
+sku = 284758393
+color = "gray"
+
+[[array-of-tables.fruit]]
+  name = "apple"
+
+  [array-of-tables.fruit.physical]
+    color = "red"
+    shape = "round"
+
+  [[array-of-tables.fruit.variety]]
+    name = "red delicious"
+
+  [[array-of-tables.fruit.variety]]
+    name = "granny smith"
+
+[[array-of-tables.fruit]]
+  name = "banana"
+
+  [[array-of-tables.fruit.variety]]
+    name = "plantain"

--- a/test/examples/invalid/inline-table-duplicate-key.toml
+++ b/test/examples/invalid/inline-table-duplicate-key.toml
@@ -1,0 +1,6 @@
+# Inline tables fully define the keys and sub-tables within them. 
+# So, inline tables can not be used to add keys
+# or sub-tables to an already-defined table.
+[product]
+type.name = "Nail"
+type = { edible = false }  # INVALID

--- a/test/examples/invalid/inline-table-duplicate-key2.toml
+++ b/test/examples/invalid/inline-table-duplicate-key2.toml
@@ -1,0 +1,5 @@
+# Inline tables fully define the keys and sub-tables within them.
+# New keys and sub-tables cannot be added to them.
+[product]
+type = { name = "Nail" }
+type.edible = false

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -148,20 +148,47 @@ class GrammarTest < Minitest::Test
   end
 
   def test_float
-    match = TomlRB::Document.parse('1.69', root: :number)
-    assert_equal(1.69, match.value)
+    match = TomlRB::Document.parse('+1.0', root: :float)
+    assert_equal(+1.0, match.value)
 
-    match = TomlRB::Document.parse('1_000.69', root: :number)
-    assert_equal(1000.69, match.value)
+    match = TomlRB::Document.parse('3.1415', root: :float)
+    assert_equal(3.1415, match.value)
 
-    match = TomlRB::Document.parse('1e6', root: :number)
+    match = TomlRB::Document.parse('-0.01', root: :float)
+    assert_equal(-0.01, match.value)
+
+    match = TomlRB::Document.parse('5e+22', root: :float)
+    assert_equal(5e+22, match.value)
+
+    match = TomlRB::Document.parse('1e6', root: :float)
     assert_equal(1e6, match.value)
 
-    match = TomlRB::Document.parse('1.02e-46', root: :number)
-    assert_equal(1.02e-46, match.value)
+    match = TomlRB::Document.parse('-2E-2', root: :float)
+    assert_equal(-2E-2, match.value)
 
-    match = TomlRB::Document.parse('+1e4_000_000', root: :number)
-    assert_equal(1e4_000_000, match.value)
+    match = TomlRB::Document.parse('6.626e-34', root: :float)
+    assert_equal(6.626e-34, match.value)
+
+    match = TomlRB::Document.parse('224_617.445_991_228', root: :float)
+    assert_equal(224_617.445_991_228, match.value)
+
+    match = TomlRB::Document.parse('inf', root: :float)
+    assert_equal(Float::INFINITY, match.value)
+
+    match = TomlRB::Document.parse('+inf', root: :float)
+    assert_equal(Float::INFINITY, match.value)
+
+    match = TomlRB::Document.parse('-inf', root: :float)
+    assert_equal(-Float::INFINITY, match.value)
+
+    match = TomlRB::Document.parse('nan', root: :float)
+    assert(match.value.nan?)
+
+    match = TomlRB::Document.parse('+nan', root: :float)
+    assert(match.value.nan?)
+
+    match = TomlRB::Document.parse('-nan', root: :float)
+    assert(match.value.nan?)
   end
 
   def test_signed_numbers

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -267,23 +267,32 @@ class GrammarTest < Minitest::Test
   # Dates are really hard to test from JSON, due the imposibility to represent
   # datetimes without quotes.
   def test_datetime
-    match = TomlRB::Document.parse('1986-08-28T15:15:00Z', root: :datetime)
-    assert_equal(Time.utc(1986, 8, 28, 15, 15), match.value)
+    match = TomlRB::Document.parse('1979-05-27T07:32:00Z', root: :datetime)
+    assert_equal(Time.utc(1979, 5, 27, 7, 32, 0), match.value)
 
-    match = TomlRB::Document.parse('1986-08-28T15:15:00-03:00', root: :datetime)
-    assert_equal(Time.utc(1986, 8, 28, 18, 15), match.value)
+    match = TomlRB::Document.parse('1979-05-27T00:32:00-07:00', root: :datetime)
+    assert_equal(Time.new(1979, 5, 27, 0, 32, 0, '-07:00'), match.value)
 
-    match = TomlRB::Document.parse('1986-08-28T15:15:00.123-03:00', root: :datetime)
-    assert_equal(Time.utc(1986, 8, 28, 18, 15, 0.123), match.value)
+    match = TomlRB::Document.parse('1979-05-27T00:32:00.999999-07:00', root: :datetime)
+    assert_equal(Time.new(1979, 5, 27, 0, 32, 0.999999, '-07:00'), match.value)
+    
+    match = TomlRB::Document.parse('1979-05-27 07:32:00Z', root: :datetime)
+    assert_equal(Time.utc(1979, 5, 27, 7, 32, 0), match.value)
 
-    match = TomlRB::Document.parse('1986-08-28', root: :datetime)
-    assert_equal(Time.utc(1986, 8, 28, 0, 0, 0), match.value)
+    match = TomlRB::Document.parse('1979-05-27T07:32:00', root: :datetime)
+    assert_equal(Time.local(1979, 5, 27, 7, 32, 0), match.value)
 
-    match = TomlRB::Document.parse('1986-08-28T15:15:00', root: :datetime)
-    assert_equal(Time.utc(1986, 8, 28, 15, 15), match.value)
+    match = TomlRB::Document.parse('1979-05-27T00:32:00.999999', root: :datetime)
+    assert_equal(Time.local(1979, 5, 27, 0, 32, 0, 999999), match.value)
 
-    match = TomlRB::Document.parse('1986-08-28T15:15:00.999999', root: :datetime)
-    assert_equal(Time.utc(1986, 8, 28, 15, 15, 0.999999), match.value)
+    match = TomlRB::Document.parse('1979-05-27', root: :datetime)
+    assert_equal(Time.local(1979, 5, 27), match.value)
+
+    match = TomlRB::Document.parse('07:32:00', root: :datetime)
+    assert_equal(Time.at(3600 * 7 + 60 * 32), match.value)
+
+    match = TomlRB::Document.parse('00:32:00.999999', root: :datetime)
+    assert_equal(Time.at(60 * 32, 999999), match.value)
   end
 
   def test_inline_table

--- a/test/grammar_test.rb
+++ b/test/grammar_test.rb
@@ -107,11 +107,44 @@ class GrammarTest < Minitest::Test
   end
 
   def test_integer
-    match = TomlRB::Document.parse('26', root: :number)
-    assert_equal(26, match.value)
+    match = TomlRB::Document.parse('+99', root: :integer)
+    assert_equal(99, match.value)
 
-    match = TomlRB::Document.parse('1_200_000_999', root: :number)
-    assert_equal(1_200_000_999, match.value)
+    match = TomlRB::Document.parse('42', root: :integer)
+    assert_equal(42, match.value)
+
+    match = TomlRB::Document.parse('0', root: :integer)
+    assert_equal(0, match.value)
+
+    match = TomlRB::Document.parse('-17', root: :integer)
+    assert_equal(-17, match.value)
+
+    match = TomlRB::Document.parse('1_000', root: :integer)
+    assert_equal(1_000, match.value)
+
+    match = TomlRB::Document.parse('5_349_221', root: :integer)
+    assert_equal(5_349_221, match.value)
+
+    match = TomlRB::Document.parse('1_2_3_4_5', root: :integer)
+    assert_equal(1_2_3_4_5, match.value)
+
+    match = TomlRB::Document.parse('0xDEADBEEF', root: :integer)
+    assert_equal(0xDEADBEEF, match.value)
+
+    match = TomlRB::Document.parse('0xdeadbeef', root: :integer)
+    assert_equal(0xdeadbeef, match.value)
+
+    match = TomlRB::Document.parse('0xdead_beef', root: :integer)
+    assert_equal(0xdead_beef, match.value)
+
+    match = TomlRB::Document.parse('0o01234567', root: :integer)
+    assert_equal(0o01234567, match.value)
+
+    match = TomlRB::Document.parse('0o755', root: :integer)
+    assert_equal(0o755, match.value)
+
+    match = TomlRB::Document.parse('0b11010110', root: :integer)
+    assert_equal(0b11010110, match.value)
   end
 
   def test_float

--- a/test/hard_example.toml
+++ b/test/hard_example.toml
@@ -32,10 +32,10 @@ key3 = 'value'
 [[a.b]]
 c = 3
 
-# Each of the following keygroups/key value pairs should produce an error. Uncomment to them to test
+# Each of the following table/key value pairs should produce an error. Uncomment to them to test
 
 #[error]   if you didn't catch this, your parser is broken
-#string = "Anything other than tabs, spaces and newline after a keygroup or key value pair has ended should produce an error unless it is a comment"   like this
+#string = "Anything other than tabs, spaces and newline after a table or key value pair has ended should produce an error unless it is a comment"   like this
 #array = [
 #         "This might most likely happen in multiline arrays",
 #         Like here,

--- a/test/toml_examples.rb
+++ b/test/toml_examples.rb
@@ -26,7 +26,7 @@ class TomlRB::Examples
       },
       "string" => {
         "basic" => {
-          "basic" => "I'm a string. \"You can quote me\". Name\tJos\\u00E9\nLocation\tSF."
+          "basic" => "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
         },
         "multiline" => {
           "key1" => "One\nTwo",
@@ -41,15 +41,11 @@ class TomlRB::Examples
         "literal" => {
           "winpath" => "C:\\Users\\nodejs\\templates",
           "winpath2" => "\\\\ServerX\\admin$\\system32\\",
-          "quoted" => "Tom\"Dubs\"Preston-Werner",
+          "quoted" => "Tom \"Dubs\" Preston-Werner",
           "regex" => "<\\i\\c*\\s*>",
           "multiline" => {
-            "regex2" => "I[
-                dw
-            ]on'tneed\\d{
-                2
-            }apples",
-            "lines" => "Thefirstnewlineis\ntrimmedinrawstrings.\nAllotherwhitespace\nispreserved.\n"
+            "regex2" => "I [dw]on't need \\d{2} apples",
+            "lines" => "The first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n"
           }
         }
       },

--- a/test/toml_examples.rb
+++ b/test/toml_examples.rb
@@ -123,6 +123,219 @@ class TomlRB::Examples
     }
   end
 
+  def self.example_v_0_5_0
+    {
+      "keys" => {
+        "key" => "value",
+        "bare_key" => "value",
+        "bare-key" => "value",
+        "1234" => "value",
+        "127.0.0.1" =>"value",
+        "character encoding" => "value",
+        "ʎǝʞ" => "value",
+        'key2' => "value",
+        'quoted "value"' => "value",
+        "name" => "Orange",
+        "physical" => {
+          "color" => "orange",
+          "shape" => "round"
+        },
+        'site' => { "google.com" => true },
+        "3" => { "14159" => "pi" },
+        "a" => {
+          "b" => { "c" => 1 },
+          "d" => 2,
+          "type" => "",
+          "name" => "",
+          "data" => ""
+        },
+        "b" => {
+          "type" => "",
+          "name" => "",
+          "data" => ""
+        }
+      },
+      "string" => {
+        "str1" => "Roses are red\nViolets are blue",
+        "str2" => "Roses are red\nViolets are blue",
+        "str3" => "Roses are red\r\nViolets are blue",
+        "same" => {
+          "str1" => "The quick brown fox jumps over the lazy dog.",
+          "str2" => "The quick brown fox jumps over the lazy dog.",
+          "str3" => "The quick brown fox jumps over the lazy dog."
+        },
+        "winpath" => 'C:\\Users\\nodejs\\templates',
+        "winpath2" => "\\\\ServerX\\admin$\\system32\\",
+        "quoted" => 'Tom "Dubs" Preston-Werner',
+        "regex" => '<\\i\\c*\\s*>',
+        "regex2" => "I [dw]on't need \\d{2} apples",
+        "lines" => "The first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n"
+      },
+      "integer" => {
+        "int1" => +99,
+        "int2" => 42,
+        "int3" => 0,
+        "int4" => -17,
+        "int5" => 1000,
+        "int6" => 5349221,
+        "int7" => 12345,
+        "hex1" => 0xDEADBEEF,
+        "hex2" => 0xdeadbeef,
+        "hex3" => 0xdead_beef,
+        "oct1" => 0o01234567,
+        "oct2" => 0o755,
+        "bin1" => 0b11010110
+      },
+      "float" => {
+        "flt1" => 1.0,
+        "flt2" => 3.1415,
+        "flt3" => -0.01,
+        "flt4" => 5e+22,
+        "flt5" => 1e06,
+        "flt6" => -2E-2,
+        "flt7" => 6.626e-34,
+        "flt8" => 224_617.445_991_228,
+        "flt9" => -0.0,
+        "flt10" => +0.0,
+        "sf1" => Float::INFINITY,
+        "sf2" => Float::INFINITY,
+        "sf3" => -Float::INFINITY,
+        "sf4" => Float::NAN,
+        "sf5" => Float::NAN,
+        "sf6" => Float::NAN
+      },
+      "boolean" => {
+        "bool1" => true,
+        "bool2" => false
+      },
+      "offset-date-time" => {
+        "odt1" => Time.new(1979, 5, 27, 7, 32, 0, "+00:00"),
+        "odt2" => Time.new(1979, 5, 27, 0, 32, 0, "-07:00"),
+        "odt3" => Time.new(1979, 5, 27, 0, 32, 0.999999, "-07:00"),
+        "odt4" => Time.new(1979, 5, 27, 7, 32, 0, "+00:00")
+      },
+      "local-date-time" => {
+        "ldt1" => Time.local(1979, 5, 27, 7, 32, 0),
+        "ldt2" => Time.local(1979, 5, 27, 0, 32, 0, 999999)
+      },
+      "local-date" => {
+        "ld1" => Time.local(1979, 5, 27)
+      },
+      "local-time" => {
+        "lt1" => Time.at(3600 * 7 + 60 * 32 + 0, 0),
+        "lt2" => Time.at(3600 * 0 + 60 * 32 + 0, 999999)
+      },
+      "array" => {
+        "arr1" => [ 1, 2, 3],
+        "arr2" => [ "red", "yellow", "green"],
+        "arr3" => [[ 1, 2 ], [3, 4, 5]],
+        "arr4" => [ "all", "strings", "are the same", "type"],
+        "arr5" => [[ 1, 2 ], ["a", "b", "c"]],
+        "arr7" => [ 1, 2, 3],
+        "arr8" => [ 1, 2]
+      },
+      "table" => {
+        "table-1" => {
+          "key1" => "some string",
+          "key2" => 123,
+        },
+        "table-2" => {
+          "key1" => "another string",
+          "key2" => 456
+        },
+        "dog" => {
+          "tater.man" => {
+            "type" => {
+              "name" => "pug"
+            }
+          }
+        },
+        "a" => {
+          "b" => {
+            "c" => {}
+          },
+          "x" => {},
+          "y" => {}
+        },
+        "d" => {
+          "e" => {
+            "f" => {}
+          }
+        },
+        "g" => {
+          "h" => {
+            "i" => {}
+          }
+        },
+        "j" => {
+          "ʞ" => {
+            'l' => {}
+          }
+        },
+        "x" => {
+          "y" => {
+            "z" => {
+              "w" => {}
+            }
+          }
+        },
+        "b" => {},
+        "fruit" => {
+          "apple" => {
+            "color" => "red",
+            "taste" => {
+              "sweet" => true
+            },
+            "texture" => {
+              "smooth" => true
+            }
+          }
+        },
+      },
+      "inline-table" => {
+        "name" => {
+          "first" => "Tom",
+          "last" => "Preston-Werner"
+        },
+        "point" => {
+          "x" => 1,
+          "y" => 2
+        },
+        "animal" => { 
+          "type" => {
+            "name" => "pug"
+          }
+        }
+      },
+      "array-of-tables" => {
+        "products" => [
+          { "name" => "Hammer", "sku" => 738594937 },
+          {},
+          { "name" => "Nail", "sku" => 284758393, "color" => "gray" }
+        ],
+        "fruit" => [
+          {
+            "name" => "apple",
+            "physical" => {
+              "color" => "red",
+              "shape" => "round"
+            },
+            "variety" => [
+              { "name" => "red delicious" },
+              { "name" => "granny smith" }
+            ]
+          },
+          {
+            "name" => "banana",
+            "variety" => [
+              { "name" => "plantain" }
+            ]
+          }
+        ]
+      }
+    }
+  end
+
   def self.example
     {
       'title' => 'TomlRB Example',

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -19,6 +19,25 @@ class TomlTest < Minitest::Test
     assert_equal hash['fruit'], parsed['fruit']
   end
 
+  def test_file_v_0_5_0
+    path = File.join(File.dirname(__FILE__), 'example-v0.5.0.toml')
+    parsed = TomlRB.load_file(path)
+    hash = TomlRB::Examples.example_v_0_5_0
+    assert_equal hash['keys'], parsed['keys']
+    assert_equal hash['string'], parsed['string']
+    assert_equal hash['integer'], parsed['integer']
+    assert_equal hash['float'], parsed['float']
+    assert_equal hash['boolean'], parsed['boolean']
+    assert_equal hash['offset-date-time'], parsed['offset-date-time']
+    assert_equal hash['local-date-time'], parsed['local-date-time']
+    assert_equal hash['local-date'], parsed['local-date']
+    assert_equal hash['local-time'], parsed['local-time']
+    assert_equal hash['array'], parsed['array']
+    assert_equal hash['table'], parsed['table']
+    assert_equal hash['inline-table'], parsed['inline-table']
+    assert_equal hash['array-of-tables'], parsed['array-of-tables']
+  end
+
   def test_file
     path = File.join(File.dirname(__FILE__), 'example.toml')
     parsed = TomlRB.load_file(path)

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -8,13 +8,13 @@ class TomlTest < Minitest::Test
     parsed = TomlRB.load_file(path)
     hash = TomlRB::Examples.example_v_0_4_0
 
-    assert_equal hash['Array'], parsed['Array']
-    assert_equal hash['Booleans'], parsed['Booleans']
-    assert_equal hash['Datetime'], parsed['Datetime']
-    assert_equal hash['Float'], parsed['Float']
-    assert_equal hash['Integer'], parsed['Integer']
-    assert_equal hash['String'], parsed['String']
-    assert_equal hash['Table'], parsed['Table']
+    assert_equal hash['array'], parsed['array']
+    assert_equal hash['boolean'], parsed['boolean']
+    assert_equal hash['datetime'], parsed['datetime']
+    assert_equal hash['float'], parsed['float']
+    assert_equal hash['integer'], parsed['integer']
+    assert_equal hash['string'], parsed['string']
+    assert_equal hash['table'], parsed['table']
     assert_equal hash['products'], parsed['products']
     assert_equal hash['fruit'], parsed['fruit']
   end


### PR DESCRIPTION
For  [toml v0.5.0](https://github.com/toml-lang/toml/blob/master/CHANGELOG.md) release,
I posted a pull request for a partial support before(see #116 ).

This time, I have made complete support and tests for toml v0.5.0.
Please consider it.

Change points
- [x] Add dotted keys.
- [x] Add hex, octal, and binary integer formats.
- [x] Add special float values (inf, nan)
- [x] Rename Datetime to Offset Date-Time.
- [x] Add Local Date-Time.
- [x] Add Local Date.
- [x] Add Local Time.
- [x] Allow space (instead of T) to separate date and time in Date-Time.