### PR TITLE
update support version 0.5.0 of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ toml-rb
 
 A [TOML](https://github.com/toml-lang/toml) parser using [Citrus](http://mjackson.github.io/citrus) library.
 
-TOML specs supported: `0.4.0`
+TOML specs supported: `0.5.0`
 
 Installation
 ------------


### PR DESCRIPTION
I requested support for 0.5.0, but I forgot to update REAMDE.

And, can I add this repo to the official wiki for the 0.5.0compliant list?
https://github.com/toml-lang/toml/wiki#v050-compliant