### PR TITLE
Fix dumping of #$

### DIFF
--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -94,7 +94,7 @@ module TomlRB
       elsif obj.is_a? Regexp
         obj.inspect.inspect
       elsif obj.is_a? String
-        obj.inspect.gsub(/\\(#[@{])/, '\1')
+        obj.inspect.gsub(/\\(#[$@{])/, '\1')
       else
         obj.inspect
       end

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -113,4 +113,10 @@ class DumperTest < Minitest::Test
     dumped = TomlRB.dump(hash)
     assert_equal 'key = "includes #@variable"' + "\n", dumped
   end
+
+  def test_dump_interpolation_dollar
+    hash = { "key" => 'includes #$variable' }
+    dumped = TomlRB.dump(hash)
+    assert_equal 'key = "includes #$variable"' + "\n", dumped
+  end
 end


### PR DESCRIPTION
Dumping '#$' produces invalid TOML as '#$'.inspect introduces a single backslash before #.