### PR TITLE
Add trailing whitespace for keyvalue and line_break rules

### DIFF
--- a/lib/toml-rb/grammars/document.citrus
+++ b/lib/toml-rb/grammars/document.citrus
@@ -15,7 +15,7 @@ grammar TomlRB::Document
   end
 
   rule keyvalue
-    (stripped_key '=' space? v:(toml_values) comment?) <TomlRB::KeyvalueParser>
+    (stripped_key '=' space? v:(toml_values) comment? space) <TomlRB::KeyvalueParser>
   end
 
   rule inline_table

--- a/lib/toml-rb/grammars/helper.citrus
+++ b/lib/toml-rb/grammars/helper.citrus
@@ -12,6 +12,6 @@ grammar TomlRB::Helper
   end
 
   rule line_break
-    (space? "\n" | space? "\r\n") { nil }
+    (space "\n" space | space "\r\n" space) { nil }
   end
 end

--- a/test/toml_test.rb
+++ b/test/toml_test.rb
@@ -112,6 +112,16 @@ class TomlTest < Minitest::Test
     assert_equal({"hello" => "world", "line_break" => true}, parsed)
   end
 
+  def test_trailing_whitespace_after_keyvalue
+    parsed = TomlRB.parse("a = 1   ")
+    assert_equal({"a" => 1}, parsed)
+  end
+
+  def test_trailing_whitespace_after_line_break
+    parsed = TomlRB.parse("[table]\r\na = 1\r\n  ")
+    assert_equal({"table" => {"a" => 1}}, parsed)
+  end
+
   def compare_toml_files(folder, file = nil, &block)
     file ||= "*"
     Dir["test/examples/#{folder}/#{file}.json"].each do |json_file|


### PR DESCRIPTION
Fixes error when there is a trailing whitespace at the end of the document.