### PR TITLE
Replace generic options hash with specific option.

### DIFF
--- a/lib/toml-rb.rb
+++ b/lib/toml-rb.rb
@@ -11,18 +11,18 @@ require_relative "toml-rb/keyvalue"
 require_relative "toml-rb/parser"
 require_relative "toml-rb/dumper"
 
-ROOT = File.dirname(File.expand_path(__FILE__))
-Citrus.load "#{ROOT}/toml-rb/grammars/helper.citrus"
-Citrus.load "#{ROOT}/toml-rb/grammars/primitive.citrus"
-Citrus.load "#{ROOT}/toml-rb/grammars/array.citrus"
-Citrus.load "#{ROOT}/toml-rb/grammars/document.citrus"
+File.dirname(File.expand_path(__FILE__)).tap do |root|
+  Citrus.load "#{root}/toml-rb/grammars/helper.citrus"
+  Citrus.load "#{root}/toml-rb/grammars/primitive.citrus"
+  Citrus.load "#{root}/toml-rb/grammars/array.citrus"
+  Citrus.load "#{root}/toml-rb/grammars/document.citrus"
+end
 
 module TomlRB
   # Public: Returns a hash from *TomlRB* content.
   #
-  # content - TomlRB string to be parsed.
-  # options - The Hash options used to refine the parser (default: {}):
-  #           :symbolize_keys - true|false (optional).
+  # content         - TomlRB string to be parsed.
+  # :symbolize_keys - true | false (default: false).
   #
   #
   # Examples
@@ -43,15 +43,14 @@ module TomlRB
   # Returns a Ruby hash representation of the content according to TomlRB spec.
   # Raises ValueOverwriteError if a key is overwritten.
   # Raises ParseError if the content has invalid TomlRB.
-  def self.parse(content, options = {})
-    Parser.new(content, options).hash
+  def self.parse(content, symbolize_keys: false)
+    Parser.new(content, symbolize_keys: symbolize_keys).hash
   end
 
   # Public: Returns a hash from a *TomlRB* file.
   #
-  # path    - TomlRB File path
-  # options - The Hash options used to refine the parser (default: {}):
-  #           :symbolize_keys - true|false (optional).
+  # path            - TomlRB File path
+  # :symbolize_keys - true|false (optional).
   #
   #
   # Examples
@@ -68,8 +67,8 @@ module TomlRB
   # Raises ParseError if the content has invalid TomlRB.
   # Raises Errno::ENOENT if the file cannot be found.
   # Raises Errno::EACCES if the file cannot be accessed.
-  def self.load_file(path, options = {})
-    TomlRB.parse(File.read(path), options)
+  def self.load_file(path, symbolize_keys: false)
+    TomlRB.parse(File.read(path), symbolize_keys: symbolize_keys)
   end
 
   # Public: Returns a *TomlRB* string from a Ruby Hash.

--- a/lib/toml-rb/parser.rb
+++ b/lib/toml-rb/parser.rb
@@ -2,12 +2,12 @@ module TomlRB
   class Parser
     attr_reader :hash
 
-    def initialize(content, options = {})
+    def initialize(content, symbolize_keys: false)
       @hash = {}
       @visited_keys = []
       @fully_defined_keys = []
       @current = @hash
-      @symbolize_keys = options[:symbolize_keys]
+      @symbolize_keys = symbolize_keys
 
       begin
         parsed = TomlRB::Document.parse(content)

--- a/lib/toml-rb/table.rb
+++ b/lib/toml-rb/table.rb
@@ -18,18 +18,20 @@ module TomlRB
       current
     end
 
-    # Fail if the key was already defined with a ValueOverwriteError
-    def ensure_key_not_defined(visited_keys)
-      fail ValueOverwriteError.new(full_key) if visited_keys.include?(full_key)
-      visited_keys << full_key
-    end
-
     def accept_visitor(parser)
       parser.visit_table self
     end
 
     def full_key
       @dotted_keys.join(".")
+    end
+
+    private
+
+    # Fail if the key was already defined with a ValueOverwriteError
+    def ensure_key_not_defined(visited_keys)
+      fail ValueOverwriteError.new(full_key) if visited_keys.include?(full_key)
+      visited_keys << full_key
     end
   end
 


### PR DESCRIPTION
In the past, we were supporting Ruby versions without named parameters and
we didn't know how many options will use for loading/parsing TOML.
Years have passed and the _interface_ is stable so we are simplifying it.

This will be useful for the adoption of Steep or defining types in Ruby 3