### PR TITLE
dumper: Support frozen strings

### DIFF
--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "date"
 
 module TomlRB
@@ -53,7 +55,7 @@ module TomlRB
     def dump_simple_pairs(simple_pairs)
       simple_pairs.each do |key, val|
         key = quote_key(key) unless bare_key? key
-        @toml_str << "#{key} = #{to_toml(val)}\n"
+        @toml_str += "#{key} = #{to_toml(val)}\n"
       end
     end
 


### PR DESCRIPTION
In Ruby 2.7 and newer, frozen strings became a thing. I maintain a
Puppet module where the dumper.rb got vendored in and frozen strings are
now enbled in the module. With this patch the dumper.rb supports frozen
strings.