### PR TITLE
Fix dumping when there are #$ in array elements.

### DIFF
--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -97,6 +97,8 @@ module TomlRB
         obj.inspect.inspect
       elsif obj.is_a? String
         obj.inspect.gsub(/\\(#[$@{])/, '\1')
+      elsif obj.is_a? Array
+        '[' + obj.map(&method(:to_toml)).join(', ') + ']'
       else
         obj.inspect
       end

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -29,6 +29,9 @@ class DumperTest < Minitest::Test
     dumped = TomlRB.dump(array: [[1, 2], %w[weird one]])
     assert_equal("array = [[1, 2], [\"weird\", \"one\"]]\n", dumped)
 
+    dumped = TomlRB.dump(array: %w[#$ #@ #{}])
+    assert_equal("array = [\"\#$\", \"\#@\", \"\#{}\"]\n", dumped)
+
     dumped = TomlRB.dump(time: Time.utc(1986, 8, 28, 15, 15))
     assert_equal("time = 1986-08-28T15:15:00Z\n", dumped)
 


### PR DESCRIPTION
There is special treatments to `#$` when dumping string values, but this does not work properly for arrays.

```ruby
require 'toml-rb'
puts TomlRB.dump(value: '#$')   # value = "#$"
puts TomlRB.dump(array: ['#$']) # array = ["\#$"]
```

This PR fixes array dumping by passing array elements to the `to_toml` method instead of calling `inspect`.