### PR TITLE
Update a logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![TOML Logo](https://github.com/toml-lang/toml/blob/master/logos/toml-100.png)
+![TOML Logo](https://github.com/toml-lang/toml/blob/main/logos/toml-100.png)
 
 
 toml-rb


### PR DESCRIPTION
A logo could not display, because of the old URL.

![image](https://user-images.githubusercontent.com/3317191/166890029-bc1ba36d-6877-44b4-a2af-66f7249883ad.png)
