### PR TITLE
fix failure to parse arrays with newline before comma

### DIFF
--- a/lib/toml-rb/grammars/array.citrus
+++ b/lib/toml-rb/grammars/array.citrus
@@ -1,36 +1,36 @@
 grammar TomlRB::Arrays
   include TomlRB::Primitive
-  
+
   rule array_comments
     (indent? (comment indent?)*)
   end
 
   rule float_array
-    (float (space "," array_comments float)*) {
+    (float (indent? "," array_comments float)*) {
       captures[:float].map(&:value)
     }
   end
 
   rule string_array
-    (string (space "," array_comments string)*) {
+    (string (indent? "," array_comments string)*) {
       captures[:string].map(&:value)
     }
   end
 
   rule integer_array
-    (integer (space "," array_comments integer)*) {
+    (integer (indent? "," array_comments integer)*) {
       captures[:integer].map(&:value)
     }
   end
 
   rule datetime_array
-    (datetime (space "," array_comments datetime)*) {
+    (datetime (indent? "," array_comments datetime)*) {
       captures[:datetime].map(&:value)
     }
   end
 
   rule bool_array
-    (bool (space "," array_comments bool)*) {
+    (bool (indent? "," array_comments bool)*) {
       captures[:bool].map(&:value)
     }
   end

--- a/test/examples/valid/arrays.json
+++ b/test/examples/valid/arrays.json
@@ -3,5 +3,6 @@
     "floats": [1.1, 2.1, 3.1, 410000.0],
     "strings": ["a", "b", "c"],
     "multiline_strings": ["This is a test string", "Other test string"],
-    "multiline_literal": ["This is a test string", "Other test string"]
+    "multiline_literal": ["This is a test string", "Other test string"],
+    "ignore_whitespace": [1,2,3,4]
 }

--- a/test/examples/valid/arrays.toml
+++ b/test/examples/valid/arrays.toml
@@ -17,3 +17,6 @@ This \
                test \
                string''',
                "Other test string"]
+ignore_whitespace = [ 1
+,2       ,3
+	,4	]


### PR DESCRIPTION
An array with newlines such as this fails to parse:

```toml
array = [1
,2]
```

According to the TOML spec, whitespace in arrays is ignored. I verified this behavior with a few TOML validators as well.

I've never done any Citrus before so feel free to fix any blunders, thanks!