### PR TITLE
Add Ruby 3.2 to CI pipeline

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', truffleruby-head]
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', truffleruby-head]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The tests pass locally, what about adding Ruby 3.2 to CI pipeline to signify Ruby 3.2 support