### PR TITLE
Support empty keys by quoting them. Fixes #147

### DIFF
--- a/lib/toml-rb/dumper.rb
+++ b/lib/toml-rb/dumper.rb
@@ -105,7 +105,7 @@ module TomlRB
     end
 
     def bare_key?(key)
-      !!key.to_s.match(/^[a-zA-Z0-9_-]*$/)
+      !!key.to_s.match(/^[a-zA-Z0-9_-]+$/)
     end
 
     # The key needs to use quotes according to TOML specs.

--- a/test/dumper_test.rb
+++ b/test/dumper_test.rb
@@ -139,4 +139,11 @@ class DumperTest < Minitest::Test
 
     assert_equal %("\\t" = "escape special chars in strings") + "\n", dumped
   end
+
+  def test_dump_empty_key
+    hash = {"" => "empty key"}
+    dumped = TomlRB.dump(hash)
+
+    assert_equal %("" = "empty key") + "\n", dumped
+  end
 end


### PR DESCRIPTION
This Fixes #147.  

toml-rb should now be able to roundtrip documents with empty keys. 