### PR TITLE
Enhance Keyvalue assignment logic and add tests for dotted keys merging

### DIFF
--- a/test/dotted_keys_merge_test.rb
+++ b/test/dotted_keys_merge_test.rb
@@ -1,0 +1,32 @@
+require 'minitest/autorun'
+require 'toml-rb'
+
+class DottedKeysMergeTest < Minitest::Test
+  def test_dotted_keys_merge
+    toml = <<~TOML
+      [tool.ruff]
+      target-version = "py310"
+      line-length = 88
+      exclude = [ ".git", ".mypy_cache", ".pytest_cache", ".venv", "__pycache__" ]
+      lint.select = ["B", "C4", "E", "F", "FAST", "I", "N", "RUF", "T20", "UP", "W"]
+      lint.ignore = ["B008", "C901", "RUF012", "RUF029", "UP007"]
+      lint.exclude = ["*.ipynb"]
+      lint.per-file-ignores = { "__init__.py" = ["F401"], "migrations/versions/*.py" = ["E501", "W291"] }
+      lint.preview = true
+    TOML
+    parsed = TomlRB.parse(toml)
+    assert_equal "py310", parsed["tool"]["ruff"]["target-version"]
+    assert_equal 88, parsed["tool"]["ruff"]["line-length"]
+    assert_equal [".git", ".mypy_cache", ".pytest_cache", ".venv", "__pycache__"], parsed["tool"]["ruff"]["exclude"]
+    assert_equal ["B", "C4", "E", "F", "FAST", "I", "N", "RUF", "T20", "UP", "W"], parsed["tool"]["ruff"]["lint"]["select"]
+    assert_equal ["B008", "C901", "RUF012", "RUF029", "UP007"], parsed["tool"]["ruff"]["lint"]["ignore"]
+    assert_equal ["*.ipynb"], parsed["tool"]["ruff"]["lint"]["exclude"]
+    assert_equal({"__init__.py"=>["F401"], "migrations/versions/*.py"=>["E501", "W291"]}, parsed["tool"]["ruff"]["lint"]["per-file-ignores"])
+    assert_equal true, parsed["tool"]["ruff"]["lint"]["preview"]
+  end
+
+  def test_duplicate_key_error
+    toml = "a.b = 1\na.b = 2"
+    assert_raises(TomlRB::ValueOverwriteError) { TomlRB.parse(toml) }
+  end
+end


### PR DESCRIPTION
This pull request introduces enhancements to the `assign` method in `lib/toml-rb/keyvalue.rb` to handle merging of nested hashes and duplicate keys more robustly, along with new tests to validate these changes. The most important changes include adding a custom merge block to handle nested hash merging, improving error handling for duplicate keys, and introducing comprehensive test coverage for these scenarios.

### Enhancements to `assign` method:

* Added a `merge_block` to handle merging of nested hashes with `dotted_key_merge` and raise `ValueOverwriteError` for conflicting values. This ensures better handling of complex TOML structures.
* Improved error handling by explicitly checking for duplicate keys in `fully_defined_keys` and raising `ValueOverwriteError` when duplicates are detected.

### Test additions:

* Added `DottedKeysMergeTest` in `test/dotted_keys_merge_test.rb` to validate parsing of complex TOML structures, ensuring nested keys and arrays are handled correctly.
* Added a test case to verify that `ValueOverwriteError` is raised when duplicate keys are encountered, improving robustness against invalid TOML inputs.