### PR TITLE
Fix encoding exception

### DIFF
--- a/lib/toml-rb/parser.rb
+++ b/lib/toml-rb/parser.rb
@@ -14,6 +14,14 @@ module TomlRB
         parsed.matches.map(&:value).compact.each { |m| m.accept_visitor(self) }
       rescue Citrus::ParseError => e
         raise TomlRB::ParseError.new(e.message)
+      rescue Encoding::CompatibilityError => e
+        raise TomlRB::ParseError.new("Encoding error: #{e.message}")
+      rescue ArgumentError => e
+        if e.message.include?("invalid byte sequence") || e.message.include?("encoding")
+          raise TomlRB::ParseError.new("Encoding error: #{e.message}")
+        else
+          raise
+        end
       end
     end
 

--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -1,0 +1,46 @@
+require_relative "helper"
+
+class EncodingTest < Minitest::Test
+  def test_binary_data_raises_parse_error
+    binary_data = "\x80\x81\x82".force_encoding("ASCII-8BIT")
+
+    assert_raises(TomlRB::ParseError) do
+      TomlRB.parse(binary_data)
+    end
+  end
+
+  def test_comment_with_high_bytes_raises_parse_error
+    # This triggers Encoding::CompatibilityError in Citrus
+    # which should be wrapped in TomlRB::ParseError
+    data = "# \xFF\xFE comment\nkey = 1".force_encoding("ASCII-8BIT")
+
+    assert_raises(TomlRB::ParseError) do
+      TomlRB.parse(data)
+    end
+  end
+
+  def test_invalid_utf8_sequence_raises_parse_error
+    invalid_utf8 = "key = \"\xC3\x28\"".force_encoding("UTF-8")
+
+    error = assert_raises(TomlRB::Error) do
+      TomlRB.parse(invalid_utf8)
+    end
+
+    assert_match(/encoding/i, error.message)
+  end
+
+  def test_valid_ascii_8bit_toml_parses
+    valid_ascii = 'key = "value"'.force_encoding("ASCII-8BIT")
+
+    result = TomlRB.parse(valid_ascii)
+    assert_equal({"key" => "value"}, result)
+  end
+
+  def test_null_bytes_raise_parse_error
+    data_with_nulls = "key\x00=\x00value".force_encoding("ASCII-8BIT")
+
+    assert_raises(TomlRB::ParseError) do
+      TomlRB.parse(data_with_nulls)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/emancu/toml-rb/issues/150

A Ruby fuzzer discovered that `toml-rb` was throwing uncaught `Encoding::CompatibilityError` exceptions instead of proper `TomlRB::ParseError` when parsing content with encoding issues. This happened when:
  - Comments contained high bytes in ASCII-8BIT encoding
  - Binary data mixed with valid TOML structure
  - Invalid UTF-8 sequences

  The error occurred deep in the Citrus parsing library: "incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)"