### PR TITLE
Fix ValueOverwriteError on quoted keys containing dots (#160)

### DIFF
--- a/lib/toml-rb/keyvalue.rb
+++ b/lib/toml-rb/keyvalue.rb
@@ -10,23 +10,23 @@ module TomlRB
       @symbolize_keys = false
     end
 
-    def assign(hash, fully_defined_keys, symbolize_keys = false)
+    def assign(hash, fully_defined_paths, symbolize_keys = false)
       @symbolize_keys = symbolize_keys
-      dotted_keys_str = @dotted_keys.join(".")
       keys = symbolize_keys ? @dotted_keys.map(&:to_sym) : @dotted_keys
+      depth = @dotted_keys.size
       update = keys.reverse.inject(visit_value(@value)) { |k1, k2| {k2 => k1} }
 
-      parent_inline_table = fully_defined_keys.find { |k| dotted_keys_str.start_with?("#{k}.") }
+      parent_inline_table = fully_defined_paths.find { |k| k.size < depth && @dotted_keys.first(k.size) == k }
       fail ValueOverwriteError.new(@dotted_keys.first) if parent_inline_table
 
       if @value.is_a?(InlineTable)
-        child_keys_exist = fully_defined_keys.find { |k| k.start_with?("#{dotted_keys_str}.") }
+        child_keys_exist = fully_defined_paths.find { |k| k.size > depth && k.first(depth) == @dotted_keys }
         fail ValueOverwriteError.new(@dotted_keys.first) if child_keys_exist
 
         existing_hash = hash.dig(*keys)
         fail ValueOverwriteError.new(@dotted_keys.first) if existing_hash.is_a?(Hash) && !existing_hash.empty?
 
-        fully_defined_keys << dotted_keys_str
+        fully_defined_paths << @dotted_keys
       end
 
       dotted_key_merge(hash, update)

--- a/lib/toml-rb/parser.rb
+++ b/lib/toml-rb/parser.rb
@@ -5,7 +5,7 @@ module TomlRB
     def initialize(content, symbolize_keys: false)
       @hash = {}
       @visited_keys = []
-      @fully_defined_keys = []
+      @fully_defined_paths = []
       @current = @hash
       @symbolize_keys = symbolize_keys
 
@@ -28,7 +28,7 @@ module TomlRB
     # Read about the Visitor pattern
     # http://en.wikipedia.org/wiki/Visitor_pattern
     def visit_table_array(table_array)
-      @fully_defined_keys = []
+      @fully_defined_paths = []
       table_array_key = table_array.full_key
       @visited_keys.reject! { |k| k.start_with? table_array_key }
 
@@ -36,12 +36,12 @@ module TomlRB
     end
 
     def visit_table(table)
-      @fully_defined_keys = []
+      @fully_defined_paths = []
       @current = table.navigate_keys @hash, @visited_keys, @symbolize_keys
     end
 
     def visit_keyvalue(keyvalue)
-      keyvalue.assign @current, @fully_defined_keys, @symbolize_keys
+      keyvalue.assign @current, @fully_defined_paths, @symbolize_keys
     end
   end
 end

--- a/test/examples/valid/inline-table/with-quoted-dotted-keys.json
+++ b/test/examples/valid/inline-table/with-quoted-dotted-keys.json
@@ -1,0 +1,15 @@
+{
+  "package": [
+    {
+      "name": "bleak",
+      "dependencies": {
+        "winrt-Windows.Devices.Bluetooth": {
+          "version": ">=3.1"
+        },
+        "winrt-Windows.Devices.Bluetooth.Advertisement": {
+          "version": ">=3.1"
+        }
+      }
+    }
+  ]
+}

--- a/test/examples/valid/inline-table/with-quoted-dotted-keys.toml
+++ b/test/examples/valid/inline-table/with-quoted-dotted-keys.toml
@@ -1,0 +1,6 @@
+[[package]]
+name = "bleak"
+
+[package.dependencies]
+"winrt-Windows.Devices.Bluetooth" = {version = ">=3.1"}
+"winrt-Windows.Devices.Bluetooth.Advertisement" = {version = ">=3.1"}


### PR DESCRIPTION
Fixes #160.

## Summary
- The fix in #157 stored each fully-defined inline-table path as a joined string (`a.b.c`) and checked parent/child collisions with `start_with?`. That couldn't distinguish a single quoted key like `"winrt-Windows.Devices.Bluetooth"` from a 3-segment unquoted dotted path, so a literal sibling key `"winrt-Windows.Devices.Bluetooth.Advertisement"` was wrongly flagged as a child.
- Store the path as the original `Array<String>` of key segments and compare structurally (length + array prefix). Quoted keys remain a single element, so dots inside them never participate in path matching.
- Rename `fully_defined_keys` → `fully_defined_paths` so the variable name matches the new contract.

## Test plan
- [x] `bundle exec rake test` — 53 runs, 538 assertions, 0 failures
- [x] New fixture `test/examples/valid/inline-table/with-quoted-dotted-keys.{toml,json}` reproduces the issue and now parses correctly
- [x] Existing #155 regression (`with-dotted-keys`) still passes