### PR TITLE
Remove Ruby warnings from encoding tests

### DIFF
--- a/test/encoding_test.rb
+++ b/test/encoding_test.rb
@@ -2,7 +2,7 @@ require_relative "helper"
 
 class EncodingTest < Minitest::Test
   def test_binary_data_raises_parse_error
-    binary_data = "\x80\x81\x82".force_encoding("ASCII-8BIT")
+    binary_data = String.new("\x80\x81\x82", encoding: "ASCII-8BIT")
 
     assert_raises(TomlRB::ParseError) do
       TomlRB.parse(binary_data)
@@ -12,7 +12,7 @@ class EncodingTest < Minitest::Test
   def test_comment_with_high_bytes_raises_parse_error
     # This triggers Encoding::CompatibilityError in Citrus
     # which should be wrapped in TomlRB::ParseError
-    data = "# \xFF\xFE comment\nkey = 1".force_encoding("ASCII-8BIT")
+    data = String.new("# \xFF\xFE comment\nkey = 1", encoding: "ASCII-8BIT")
 
     assert_raises(TomlRB::ParseError) do
       TomlRB.parse(data)
@@ -20,7 +20,7 @@ class EncodingTest < Minitest::Test
   end
 
   def test_invalid_utf8_sequence_raises_parse_error
-    invalid_utf8 = "key = \"\xC3\x28\"".force_encoding("UTF-8")
+    invalid_utf8 = String.new("key = \"\xC3\x28\"", encoding: "UTF-8")
 
     error = assert_raises(TomlRB::Error) do
       TomlRB.parse(invalid_utf8)
@@ -30,14 +30,14 @@ class EncodingTest < Minitest::Test
   end
 
   def test_valid_ascii_8bit_toml_parses
-    valid_ascii = 'key = "value"'.force_encoding("ASCII-8BIT")
+    valid_ascii = String.new('key = "value"', encoding: "ASCII-8BIT")
 
     result = TomlRB.parse(valid_ascii)
     assert_equal({"key" => "value"}, result)
   end
 
   def test_null_bytes_raise_parse_error
-    data_with_nulls = "key\x00=\x00value".force_encoding("ASCII-8BIT")
+    data_with_nulls = String.new("key\x00=\x00value", encoding: "ASCII-8BIT")
 
     assert_raises(TomlRB::ParseError) do
       TomlRB.parse(data_with_nulls)


### PR DESCRIPTION
## Summary
- Replaces `String#force_encoding` on frozen string literals with `String.new(..., encoding:)`, silencing the mutability warning emitted by modern Ruby.
- No behavior change.

## Test plan
- [x] `bundle exec rake test` — 53 runs, 538 assertions, 0 failures
- [x] All 5 encoding tests pass
- [x] No Ruby warnings remain in the suite output