### PR TITLE
Support multi-line inline tables and trailing commas (#161)

### DIFF
--- a/lib/toml-rb/grammars/document.citrus
+++ b/lib/toml-rb/grammars/document.citrus
@@ -20,7 +20,7 @@ grammar TomlRB::Document
   ### Values
 
   rule inline_table
-    (space? '{' (keyvalue? (',' keyvalue)*)? space? '}' ) <TomlRB::InlineTableParser>
+    (space? '{' array_comments (keyvalue (array_comments ',' array_comments keyvalue)* (array_comments ',')?)? array_comments '}' ) <TomlRB::InlineTableParser>
   end
 
   rule array

--- a/test/examples/valid/inline-table/multiline.json
+++ b/test/examples/valid/inline-table/multiline.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "windows-sys": {
+      "version": "0.61.2",
+      "features": [
+        "Win32_System_Environment",
+        "Win32_Storage_FileSystem",
+        "Win32_System_Memory"
+      ]
+    },
+    "empty": {},
+    "single": {
+      "a": 1,
+      "b": 2
+    },
+    "with-comments": {
+      "x": 1,
+      "y": 2
+    }
+  }
+}

--- a/test/examples/valid/inline-table/multiline.toml
+++ b/test/examples/valid/inline-table/multiline.toml
@@ -1,0 +1,21 @@
+[dependencies]
+windows-sys = {
+  version = "0.61.2",
+  features = [
+    "Win32_System_Environment",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Memory",
+  ],
+}
+
+empty = {
+
+}
+
+single = { a = 1, b = 2 }
+
+with-comments = {
+  # leading comment
+  x = 1, # trailing comment
+  y = 2,
+}


### PR DESCRIPTION
Fixes #161.

## Summary
- TOML 1.1 permits inline tables to span multiple lines and allows a trailing comma after the last key/value pair ([spec ref](https://toml.io/en/v1.1.0#inline-table)).
- Grammar change: relax the `inline_table` rule to accept `array_comments` (whitespace + comments) between the braces, key/value pairs, and commas, plus an optional trailing comma after the final pair. Reuses the same machinery already used inside arrays.
- Single-line inline tables are unchanged. Missing-comma between entries and bare-comma-only bodies remain invalid.

## Examples now parsed
```toml
[dependencies]
windows-sys = {
  version = "0.61.2",
  features = [
    "Win32_System_Environment",
    "Win32_Storage_FileSystem",
    "Win32_System_Memory",
  ],
}
```

## Versioning
Targets **4.2.0** (minor). This change is additive at the grammar level — every previously valid TOML 1.0 document still parses to the identical hash. However, inputs containing multi-line inline tables or trailing commas previously raised `TomlRB::ParseError` and now parse successfully. If a downstream consumer relied on those errors as a 1.0-strict validation gate, that gate no longer fires. Hence minor, not patch.

## Test plan
- [x] `bundle exec rake test` — 53 runs, 539 assertions, 0 failures
- [x] New fixture `test/examples/valid/inline-table/multiline.{toml,json}` covers multi-line, empty, single-line, comments, and trailing commas
- [x] All 303 invalid fixtures still reject
- [x] Issue #161 reproducer parses to the expected hash